### PR TITLE
Add back integration tests which were removed in 276f779

### DIFF
--- a/integration-tests/integration_tests/integration_tests/end_to_end_tests/common_assertions.py
+++ b/integration-tests/integration_tests/integration_tests/end_to_end_tests/common_assertions.py
@@ -1,0 +1,33 @@
+from integration_tests.amq.amq_message_assertor import AMQMessageAssertor
+from integration_tests.db.mhs_table import MhsTableStateAssertor
+from integration_tests.xml.hl7_xml_assertor import Hl7XmlResponseAssertor
+
+
+class CommonAssertions(object):
+    def __init__(self, workflow):
+        self.workflow = workflow
+
+    def spline_reply_published_to_message_queue(self, amq_assertor: AMQMessageAssertor, message_id, correlation_id):
+        """
+        Verifies that the message queue contains an inbound response with the specified message id
+        @param amq_assertor: the assertor instance
+        @param message_id: message id to look for
+        """
+        amq_assertor \
+            .assert_property('message-id', message_id) \
+            .assert_property('correlation-id', correlation_id) \
+            .assert_json_content_type()
+
+    def message_status_recorded_as_successfully_processed(self, state_table_assertor: MhsTableStateAssertor, message_id):
+        return state_table_assertor \
+            .assert_single_item_exists_with_key(message_id) \
+            .assert_item_contains_values({
+                'INBOUND_STATUS': 'INBOUND_RESPONSE_SUCCESSFULLY_PROCESSED',
+                'OUTBOUND_STATUS': 'OUTBOUND_MESSAGE_ACKD',
+                'WORKFLOW': f'{self.workflow}'
+        })
+
+    def hl7_xml_contains_response_code_and_patient_id(self, hl7_xml_message_assertor: Hl7XmlResponseAssertor):
+        hl7_xml_message_assertor \
+            .assert_element_attribute('.//queryAck//queryResponseCode', 'code', 'OK') \
+            .assert_element_attribute('.//patient//id', 'extension', '9691035456')

--- a/integration-tests/integration_tests/integration_tests/end_to_end_tests/int_asynchronous_express_messaging_pattern_tests.py
+++ b/integration-tests/integration_tests/integration_tests/end_to_end_tests/int_asynchronous_express_messaging_pattern_tests.py
@@ -1,0 +1,82 @@
+"""
+Provides tests around the Asynchronous Express workflow, including sync-async wrapping
+"""
+import uuid
+from unittest import TestCase
+
+from integration_tests.amq.amq_message_assertor import AMQMessageAssertor
+from integration_tests.amq.mhs_inbound_queue import MHS_INBOUND_QUEUE
+from integration_tests.assertors.assert_with_retries import AssertWithRetries
+from integration_tests.db.db_wrapper_factory import MHS_STATE_TABLE_WRAPPER, MHS_SYNC_ASYNC_TABLE_WRAPPER
+from integration_tests.db.mhs_table import MhsTableStateAssertor
+from integration_tests.db.sync_async_mhs_table import SyncAsyncMhsTableStateAssertor
+from integration_tests.end_to_end_tests.common_assertions import CommonAssertions
+from integration_tests.helpers.build_message import build_message
+from integration_tests.helpers.concurrent_requests import send_messages_concurrently, \
+    assert_all_messages_succeeded
+from integration_tests.http.mhs_http_request_builder import MhsHttpRequestBuilder
+
+
+class AsynchronousExpressMessagingPatternTests(TestCase):
+    """
+     These tests show an asynchronous express response from Spine via the MHS for the example message interaction of PSIS
+    (Personal Spine Information Service).
+
+    Asynchronous message interaction:
+    - Message sent: PSIS Document List Data Request (QUPC_IN160101UK05)
+    - Expected response: PSIS Document List Data Retrieval (QUPC_IN160102UK05)
+
+    Flow documented at:
+    - https://data.developer.nhs.uk/dms/mim/6.3.01/Index.htm
+        -> Domains - Health and Clinical Management
+            -> PSIS Query
+                -> 6.1 (Request)
+                -> 6.2 (Response)
+    """
+
+    def setUp(self):
+        MHS_STATE_TABLE_WRAPPER.clear_all_records_in_table()
+        MHS_SYNC_ASYNC_TABLE_WRAPPER.clear_all_records_in_table()
+        MHS_INBOUND_QUEUE.drain()
+        self.assertions = CommonAssertions('async-express')
+
+    def test_should_return_successful_response_from_spine_to_message_queue(self):
+        # Arrange
+        message, message_id = build_message('QUPC_IN160101UK05', '9691035456')
+        correlation_id = str(uuid.uuid4())
+
+        # Act
+        MhsHttpRequestBuilder() \
+            .with_headers(interaction_id='QUPC_IN160101UK05',
+                          message_id=message_id,
+                          wait_for_response=False,
+                          correlation_id=correlation_id) \
+            .with_body(message) \
+            .execute_post_expecting_success()
+
+        AssertWithRetries(retry_count=10) \
+            .assert_condition_met(lambda: MhsTableStateAssertor.wait_for_inbound_response_processed(message_id))
+
+        amq_assertor = AMQMessageAssertor(MHS_INBOUND_QUEUE.get_next_message_on_queue()) \
+            .assert_durable_is(True)
+        state_table_assertor = MhsTableStateAssertor(MHS_STATE_TABLE_WRAPPER.get_all_records_in_table())
+
+        self.assertions.spline_reply_published_to_message_queue(amq_assertor, message_id, correlation_id)
+        hl7_xml_message_assertor = amq_assertor.assertor_for_hl7_xml_message()
+        self.assertions.hl7_xml_contains_response_code_and_patient_id(hl7_xml_message_assertor)
+        self.assertions.message_status_recorded_as_successfully_processed(state_table_assertor, message_id)
+
+    def test_should_return_successful_response_and_record_spine_reply_in_resync_table_if_wait_for_response_requested(self):
+        # Arrange
+        messages = [build_message('QUPC_IN160101UK05', '9691035456') for _ in range(1)]
+
+        # Act
+        responses = send_messages_concurrently(messages, interaction_id='QUPC_IN160101UK05', wait_for_response=True)
+
+        # Assert
+        all_sync_async_states = MHS_SYNC_ASYNC_TABLE_WRAPPER.get_all_records_in_table()
+        assert_all_messages_succeeded(responses)
+        sync_async_state_assertor = SyncAsyncMhsTableStateAssertor(all_sync_async_states)
+        for message, message_id in messages:
+            hl7_xml_message_assertor = sync_async_state_assertor.assert_single_item_exists_with_key(message_id)
+            self.assertions.hl7_xml_contains_response_code_and_patient_id(hl7_xml_message_assertor)

--- a/integration-tests/integration_tests/integration_tests/end_to_end_tests/int_asynchronous_reliable_messaging_pattern_tests.py
+++ b/integration-tests/integration_tests/integration_tests/end_to_end_tests/int_asynchronous_reliable_messaging_pattern_tests.py
@@ -1,0 +1,107 @@
+"""
+Provides tests around the Asynchronous Reliable workflow, including sync-async wrapping
+"""
+import uuid
+from datetime import datetime
+from unittest import TestCase, skipIf
+
+from integration_tests.amq.amq_message_assertor import AMQMessageAssertor
+from integration_tests.amq.mhs_inbound_queue import MHS_INBOUND_QUEUE
+from integration_tests.assertors.assert_with_retries import AssertWithRetries
+from integration_tests.db.db_wrapper_factory import MHS_STATE_TABLE_WRAPPER, MHS_SYNC_ASYNC_TABLE_WRAPPER
+from integration_tests.db.mhs_table import MhsTableStateAssertor
+from integration_tests.db.sync_async_mhs_table import SyncAsyncMhsTableStateAssertor
+from integration_tests.end_to_end_tests.common_assertions import CommonAssertions
+from integration_tests.helpers.build_message import build_message
+from integration_tests.helpers.concurrent_requests import send_messages_concurrently, \
+    assert_all_messages_succeeded
+from integration_tests.http.mhs_http_request_builder import MhsHttpRequestBuilder
+from integration_tests.xml.hl7_xml_assertor import Hl7XmlResponseAssertor
+
+@skipIf(datetime.now() < datetime(2023, 12, 24), "Skipped for 1 week or until failures are addressed by NIAD-2842 ")
+class AsynchronousReliableMessagingPatternTests(TestCase):
+    """
+     These tests show an asynchronous reliable response from Spine via the MHS for the example message interaction of
+     GP Summary.
+
+    Asynchronous message interaction:
+    - Message sent: GP Summary (REPC_IN150016UK05)
+    - Expected response: Application Acknowledgement (MCCI_IN010000UK13)
+
+    Flow documented at:
+    - https://data.developer.nhs.uk/dms/mim/6.3.01/Index.htm
+        -> Domains - Health and Clinical Management
+            -> GP Summary
+                -> 7.2 (Request)
+            -> Infrastructure
+                -> 4.2 (Response)
+    """
+
+    def setUp(self):
+        MHS_STATE_TABLE_WRAPPER.clear_all_records_in_table()
+        MHS_SYNC_ASYNC_TABLE_WRAPPER.clear_all_records_in_table()
+        MHS_INBOUND_QUEUE.drain()
+        self.assertions = CommonAssertions('async-reliable')
+
+    def _assert_gp_summary_upload_success_detail_is_present(self, hl7_xml_assertor: Hl7XmlResponseAssertor):
+        hl7_xml_assertor.assert_element_exists_with_value('.//requestSuccessDetail//detail', 'GP Summary upload successful')
+
+    def test_should_return_successful_response_from_spine_to_message_queue(self):
+        # Arrange
+        message, message_id = build_message('REPC_IN150016UK05', '9446245796')
+        correlation_id = str(uuid.uuid4())
+        # Act
+        MhsHttpRequestBuilder() \
+            .with_headers(interaction_id='REPC_IN150016UK05',
+                          message_id=message_id,
+                          wait_for_response=False,
+                          correlation_id=correlation_id) \
+            .with_body(message) \
+            .execute_post_expecting_success()
+
+        # Assert
+        amq_assertor = AMQMessageAssertor(MHS_INBOUND_QUEUE.get_next_message_on_queue()) \
+            .assert_durable_is(True)
+        self.assertions.spline_reply_published_to_message_queue(amq_assertor, message_id, correlation_id)
+        hl7_xml_assertor = amq_assertor.assertor_for_hl7_xml_message()
+        self._assert_gp_summary_upload_success_detail_is_present(hl7_xml_assertor)
+
+    def test_should_record_asynchronous_reliable_message_status_as_successful(self):
+        # Arrange
+        message, message_id = build_message('REPC_IN150016UK05', '9446245796')
+
+        # Act
+        MhsHttpRequestBuilder() \
+            .with_headers(interaction_id='REPC_IN150016UK05',
+                          message_id=message_id,
+                          wait_for_response=False,
+                          correlation_id=str(uuid.uuid4())) \
+            .with_body(message) \
+            .execute_post_expecting_success()
+
+        # Assert
+        hl7_xml_assertor = AMQMessageAssertor(MHS_INBOUND_QUEUE.get_next_message_on_queue())\
+            .assertor_for_hl7_xml_message()
+        self._assert_gp_summary_upload_success_detail_is_present(hl7_xml_assertor)
+
+        AssertWithRetries(retry_count=10) \
+            .assert_condition_met(lambda: MhsTableStateAssertor.wait_for_inbound_response_processed(message_id))
+
+        dynamo_assertor = MhsTableStateAssertor(MHS_STATE_TABLE_WRAPPER.get_all_records_in_table())
+        self.assertions.message_status_recorded_as_successfully_processed(dynamo_assertor, message_id)
+
+    def test_should_return_successful_response_and_record_spline_reply_in_resync_table_if_wait_for_response_requested(self):
+        # Arrange
+        messages = [build_message('REPC_IN150016UK05', '9446245796') for i in range(1)]
+
+        # Act
+        responses = send_messages_concurrently(messages, interaction_id='REPC_IN150016UK05', wait_for_response=True)
+
+        # Assert
+        all_sync_async_states = MHS_SYNC_ASYNC_TABLE_WRAPPER.get_all_records_in_table()
+        assert_all_messages_succeeded(responses)
+        sync_async_state_assertor = SyncAsyncMhsTableStateAssertor(all_sync_async_states)
+        for message, message_id in messages:
+            hl7_xml_assertor = sync_async_state_assertor \
+                .assert_single_item_exists_with_key(message_id)
+            self._assert_gp_summary_upload_success_detail_is_present(hl7_xml_assertor)

--- a/integration-tests/integration_tests/integration_tests/end_to_end_tests/int_forward_reliable_messaging_pattern_tests.py
+++ b/integration-tests/integration_tests/integration_tests/end_to_end_tests/int_forward_reliable_messaging_pattern_tests.py
@@ -1,0 +1,119 @@
+"""
+Provides tests around the Forward Reliable workflow, including sync-async wrapping
+"""
+import os
+import unittest
+from unittest import TestCase
+
+from integration_tests.amq.amq_message_assertor import AMQMessageAssertor
+from integration_tests.amq.mhs_inbound_queue import MHS_INBOUND_QUEUE
+from integration_tests.assertors.assert_with_retries import AssertWithRetries
+from integration_tests.db.db_wrapper_factory import MHS_STATE_TABLE_WRAPPER, MHS_SYNC_ASYNC_TABLE_WRAPPER
+from integration_tests.db.mhs_table import MhsTableStateAssertor
+from integration_tests.end_to_end_tests.common_assertions import CommonAssertions
+from integration_tests.helpers.build_message import build_message
+from integration_tests.http.mhs_http_request_builder import MhsHttpRequestBuilder
+
+
+class ForwardReliableMessagingPatternTests(TestCase):
+    """
+     These tests show forward reliable response from Spine via the MHS for the example message interaction of
+     Common Content Forward Reliable GP2GP Large Message Attachment.
+
+    Asynchronous message interaction:
+    - Message sent: Common Content Forward Reliable (COPC_IN000001UK01)
+    - Expected response: Application Acknowledgement (MCCI_IN010000UK13)
+
+    Flow documented at:
+    - https://gpitbjss.atlassian.net/wiki/spaces/RTDel/pages/1561165837/Document+Library?preview=/1561165837/1561198617/2087%20EIS11.6--Part%203--MessageInteractionMap.doc
+        -> 3.22 Common Content
+            -> 3.22.1.1 (Request)
+            -> 3.22.1.1 (Response)
+
+    The to_party_id, and to_asid are fixed values that the forward reliable responder in opentest will respond to.
+    If failures are seen here, it is probably an issue with opentest SDS not being correctly configured for your account.
+    """
+
+    def setUp(self):
+        MHS_STATE_TABLE_WRAPPER.clear_all_records_in_table()
+        MHS_SYNC_ASYNC_TABLE_WRAPPER.clear_all_records_in_table()
+        MHS_INBOUND_QUEUE.drain()
+        self.assertions = CommonAssertions('forward-reliable')
+
+    @unittest.skipIf(os.environ.get('SKIP_FORWARD_RELIABLE_INT_TEST'), 'skipping because SKIP_FORWARD_RELIABLE_INT_TEST is set')
+    def test_should_return_successful_response_from_spine_to_message_queue(self):
+        # Arrange
+        message, message_id = build_message('COPC_IN000001UK01', to_party_id='X26-9199246', to_asid='918999199246')
+
+        attachments = [{
+            'content_type': 'text/plain',
+            'is_base64': False,
+            'description': 'Some description',
+            'payload': 'Some payload'
+        }]
+
+        external_attachments = [{
+            'document_id': 'B6D2FFAF-1EE1-4023-B639-442E1CC931DB',
+            'message_id': '4AB8A3EA-A6A6-45C3-B1EA-FF588F054A2B',
+            'description': 'some description'
+        }]
+
+        # Act
+        MhsHttpRequestBuilder() \
+            .with_headers(interaction_id='COPC_IN000001UK01',
+                          message_id=message_id,
+                          wait_for_response=False,
+                          correlation_id=message_id,
+                          ods_code='X26') \
+            .with_body(message, attachments=attachments, external_attachments=external_attachments) \
+            .execute_post_expecting_success()
+
+        # Assert
+        AMQMessageAssertor(MHS_INBOUND_QUEUE.get_next_message_on_queue()) \
+            .assert_durable_is(True) \
+            .assert_property('message-id', message_id) \
+            .assert_property('correlation-id', message_id) \
+            .assert_json_content_type() \
+            .assertor_for_hl7_xml_message() \
+            .assert_element_attribute('.//acknowledgement//messageRef//id', 'root', message_id)
+
+    @unittest.skipIf(os.environ.get('SKIP_FORWARD_RELIABLE_INT_TEST'), 'skipping because SKIP_FORWARD_RELIABLE_INT_TEST is set')
+    def test_should_record_forward_reliable_message_status_as_successful(self):
+        # Arrange
+        # The to_party_id, and to_asid are fixed values that the forward reliable responder in opentest will respond to.
+        # If failures are seen here, it is probably an issue with opentest SDS not being correctly configured for your
+        # account
+        message, message_id = build_message('COPC_IN000001UK01', to_party_id='X26-9199246', to_asid='918999199246')
+
+        attachments = [{
+            'content_type': 'text/plain',
+            'is_base64': False,
+            'description': 'Some description',
+            'payload': 'Some payload'
+        }]
+
+        # Act
+        MhsHttpRequestBuilder() \
+            .with_headers(interaction_id='COPC_IN000001UK01',
+                          message_id=message_id,
+                          wait_for_response=False,
+                          correlation_id=message_id,
+                          ods_code='X26') \
+            .with_body(message, attachments=attachments) \
+            .execute_post_expecting_success()
+
+        # Assert
+        AMQMessageAssertor(MHS_INBOUND_QUEUE.get_next_message_on_queue()) \
+            .assertor_for_hl7_xml_message() \
+            .assert_element_attribute('.//acknowledgement//messageRef//id', 'root', message_id)
+
+        AssertWithRetries(retry_count=10) \
+            .assert_condition_met(lambda: MhsTableStateAssertor.wait_for_inbound_response_processed(message_id))
+
+        MhsTableStateAssertor(MHS_STATE_TABLE_WRAPPER.get_all_records_in_table()) \
+            .assert_single_item_exists_with_key(message_id) \
+            .assert_item_contains_values({
+            'INBOUND_STATUS': 'INBOUND_RESPONSE_SUCCESSFULLY_PROCESSED',
+            'OUTBOUND_STATUS': 'OUTBOUND_MESSAGE_ACKD',
+            'WORKFLOW': 'forward-reliable'
+        })

--- a/integration-tests/integration_tests/integration_tests/end_to_end_tests/int_synchronous_messaging_pattern_tests.py
+++ b/integration-tests/integration_tests/integration_tests/end_to_end_tests/int_synchronous_messaging_pattern_tests.py
@@ -1,0 +1,76 @@
+"""
+Provides tests around the Synchronous workflow
+"""
+import uuid
+from unittest import TestCase
+
+from integration_tests.db.db_wrapper_factory import MHS_STATE_TABLE_WRAPPER
+from integration_tests.db.mhs_table import MhsTableStateAssertor
+from integration_tests.helpers.build_message import build_message
+from integration_tests.http.mhs_http_request_builder import MhsHttpRequestBuilder
+from integration_tests.xml.hl7_xml_assertor import Hl7XmlResponseAssertor
+
+
+class SynchronousMessagingPatternTests(TestCase):
+    """
+    These tests show a synchronous response from Spine via the MHS for the example message interaction of PDS
+    (Personal Demographics Service).
+
+    Synchronous message testing interaction:
+    - Message sent: PDS Retrieval Query (QUPA_IN040000UK32)
+    - Expected response: PDS Retrieval Query Successful (QUPA_IN050000UK32)
+
+    Flow documented at:
+    - https://data.developer.nhs.uk/dms/mim/4.2.00/Index.htm
+        -> Domains
+            -> PDS
+                -> 6.4 (Request)
+                -> 6.5 (Response)
+    """
+
+    def setUp(self):
+        MHS_STATE_TABLE_WRAPPER.clear_all_records_in_table()
+
+    def test_should_return_successful_response_from_spine_in_original_post_request_body(self):
+        # Arrange
+        message, message_id = build_message('QUPA_IN040000UK32', '9691813343')
+
+        # Act
+        response = MhsHttpRequestBuilder() \
+            .with_headers(
+                interaction_id='QUPA_IN040000UK32',
+                message_id=message_id,
+                wait_for_response=False,
+                correlation_id=str(uuid.uuid4())) \
+            .with_body(message) \
+            .execute_post_expecting_success()
+
+        # Assert
+        Hl7XmlResponseAssertor(response.text) \
+            .assert_element_exists('.//PdsSuccessfulRetrieval') \
+            .assert_element_attribute('.//queryAck//queryResponseCode', 'code', 'OK') \
+            .assert_element_attribute('.//patientRole//id', 'extension', '9691813343') \
+            .assert_element_attribute('.//messageRef//id', 'root', message_id)
+
+    def test_should_record_synchronous_message_status_as_successful(self):
+        # Arrange
+        message, message_id = build_message('QUPA_IN040000UK32', '9691813343')
+
+        # Act
+        MhsHttpRequestBuilder() \
+            .with_headers(
+                interaction_id='QUPA_IN040000UK32',
+                message_id=message_id,
+                wait_for_response=False,
+                correlation_id=str(uuid.uuid4())) \
+            .with_body(message) \
+            .execute_post_expecting_success()
+
+        # Assert
+        MhsTableStateAssertor(MHS_STATE_TABLE_WRAPPER.get_all_records_in_table()) \
+            .assert_single_item_exists_with_key(message_id) \
+            .assert_item_contains_values({
+            'INBOUND_STATUS': None,
+            'OUTBOUND_STATUS': 'SYNC_RESPONSE_SUCCESSFUL',
+            'WORKFLOW': 'sync'
+        })


### PR DESCRIPTION
## Why

They may be useful when run against the PTL environment

## Type of change

Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
