### PR TITLE
Remove the local-docker-compose-environment lock from Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -132,9 +132,6 @@ pipeline {
             //parallel {
             stages {
                 stage('Run Component Tests (SpineRouteLookup)') {
-                    options {
-                        lock('local-docker-compose-environment')
-                    }
                     stages {
                         stage('Deploy component locally (SpineRouteLookup)') {
                             steps {
@@ -188,9 +185,6 @@ pipeline {
                 }
 
                 stage('Run Component Tests (SDS API)') {
-                    options {
-                        lock('local-docker-compose-environment')
-                    }
                     stages {
                         stage('Deploy component locally (SDS API)') {
                             steps {


### PR DESCRIPTION
## Why

Each build in Jenkins is run on its own EC2 instance, therefore any docker commands will only affect that EC2 instance.

The current global local-docker-compose-environment lock is preventing concurrency across EC2 instances.

This lock would only make sense if builds were being performed on the same Docker daemon.

## Type of change

Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
