### PR TITLE
Remove blank versions from setup.py

### DIFF
--- a/common/setup.py
+++ b/common/setup.py
@@ -2,7 +2,6 @@ from setuptools import setup, find_packages
 
 setup(
     name='integration-adaptors-common',
-    version='',
     packages=find_packages(),
     url='https://github.com/nhsconnect/integration-adaptor-common',
     license='',

--- a/examples/SCR/setup.py
+++ b/examples/SCR/setup.py
@@ -4,7 +4,6 @@ import setuptools
 
 setup(
     name='scr',
-    version='',
     packages=setuptools.find_packages(),
     url='',
     license='',

--- a/mhs/common/setup.py
+++ b/mhs/common/setup.py
@@ -4,7 +4,6 @@ import setuptools
 
 setup(
     name='mhs-common',
-    version='',
     packages=setuptools.find_packages(),
     url='',
     license='',


### PR DESCRIPTION
## Why

In Python 3.8 this blank version value causes setuptools to throw an error

> setuptools.extern.packaging.version.InvalidVersion: Invalid version: ''

## Type of change

Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
