### PR TITLE
Update ECR login command to use non-deprecated get-login-password

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -482,8 +482,7 @@ void buildModules(String action) {
 }
 
 int ecrLogin(String aws_region) {
-    String ecrCommand = "aws ecr get-login --region ${aws_region}"
-    String dockerLogin = sh (label: "Getting Docker login from ECR", script: ecrCommand, returnStdout: true).replace("-e none","") // some parameters that AWS provides and docker does not recognize
+    String dockerLogin = "aws ecr get-login-password --region ${aws_region} | docker login -u AWS --password-stdin \"https://\$(aws sts get-caller-identity --query 'Account' --output text).dkr.ecr.${aws_region}.amazonaws.com\""
     return sh(label: "Logging in with Docker", script: dockerLogin, returnStatus: true)
 }
 

--- a/ecr_push.Jenkinsfile
+++ b/ecr_push.Jenkinsfile
@@ -33,8 +33,7 @@ pipeline {
 }
 
 int ecrLogin(String aws_region) {
-    String ecrCommand = "aws ecr get-login --region ${aws_region}"
-    String dockerLogin = sh (label: "Getting Docker login from ECR", script: ecrCommand, returnStdout: true).replace("-e none","") // some parameters that AWS provides and docker does not recognize
+    String dockerLogin = "aws ecr get-login-password --region ${aws_region} | docker login -u AWS --password-stdin \"https://\$(aws sts get-caller-identity --query 'Account' --output text).dkr.ecr.${aws_region}.amazonaws.com\""
     return sh(label: "Logging in with Docker", script: dockerLogin, returnStatus: true)
 }
 


### PR DESCRIPTION
## Why

get-login is deprecated

## Type of change

Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
