### PR TITLE
Symlink the TLS directory to certs

### DIFF
--- a/mhs/outbound/Dockerfile
+++ b/mhs/outbound/Dockerfile
@@ -24,6 +24,9 @@ ENV PYTHONPATH "${PYTHONPATH}:/usr/src/app/common"
 RUN pipenv --python 3.9
 RUN pipenv install --deploy --ignore-pipfile
 
+# PYCURL expects certificate to live in /etc/pki/tls, Debian is providing the cert in ssl/certs
+RUN mkdir -p /etc/pki/tls && ln -s /etc/ssl/certs /etc/pki/tls/certs && ln -s ca-certificates.crt /etc/ssl/certs/ca-bundle.crt
+
 EXPOSE 80
 
 ENTRYPOINT pipenv run start


### PR DESCRIPTION
## Why

PyCURL expects the certificates to live in /etc/pki/tls folder.

Symlink the contents, so that it becomes happy.

## Type of change

Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
