### PR TITLE
Remove compiling Python as part of the build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,30 +19,6 @@ pipeline {
     }
 
     stages {
-        stage('Determine python version') {
-            steps {
-                script {
-                    def python_version = sh(script: "python3 --version", returnStdout: true).trim()
-                    echo "Current Python version: ${python_version}"
-                }
-            }
-        }
-        stage('Prepare and download Python 3.9') {
-            steps {
-                sh 'apt update –fix-missing -y | echo'
-                sh 'apt install -y build-essential libssl-dev libffi-dev zlib1g-dev libbz2-dev wget curl xz-utils'
-                sh 'wget https://www.python.org/ftp/python/3.9.19/Python-3.9.19.tgz'
-                sh 'tar -xvzf Python-3.9.19.tgz'
-            }
-        }
-        stage('Compile and install Python 3.9') {
-            steps {
-                dir('Python-3.9.19') {
-                    sh './configure --enable-optimizations'
-                    sh 'make altinstall'
-                }
-            }
-        }
         stage('Build & test Common') {
             steps {
                 dir('common') {


### PR DESCRIPTION
## Why

Is very slow, and Python 3.9 is now part of the Jenkins Worker image.

## Type of change

Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
