### PR TITLE
Outbound: Specify the OpenSSL Root CA Bundle when making SDS requests

### DIFF
--- a/common/comms/common_https.py
+++ b/common/comms/common_https.py
@@ -45,7 +45,7 @@ class CommonHttps(object):
             logger.warning("Server certificate validation has been disabled.")
 
         if ca_certs is None:
-            ca_certs = ssl.get_default_verify_paths().openssl_cafile
+            ca_certs = ssl.get_default_verify_paths().cafile
 
         response = await httpclient.AsyncHTTPClient().fetch(url,
                                                             raise_error=raise_error_response,

--- a/common/comms/common_https.py
+++ b/common/comms/common_https.py
@@ -4,6 +4,7 @@ from tornado import httpclient
 
 from utilities import integration_adaptors_logger as log
 import logging
+import ssl
 
 logger = log.IntegrationAdaptorsLogger(__name__)
 
@@ -44,7 +45,7 @@ class CommonHttps(object):
             logger.warning("Server certificate validation has been disabled.")
 
         if ca_certs is None:
-            ca_certs = "/etc/pki/tls/certs/ca-certificates.crt"
+            ca_certs = ssl.get_default_verify_paths().cafile
 
         response = await httpclient.AsyncHTTPClient().fetch(url,
                                                             raise_error=raise_error_response,

--- a/common/comms/common_https.py
+++ b/common/comms/common_https.py
@@ -45,7 +45,7 @@ class CommonHttps(object):
             logger.warning("Server certificate validation has been disabled.")
 
         if ca_certs is None:
-            ca_certs = ssl.get_default_verify_paths().cafile
+            ca_certs = ssl.get_default_verify_paths().openssl_cafile
 
         response = await httpclient.AsyncHTTPClient().fetch(url,
                                                             raise_error=raise_error_response,

--- a/common/comms/common_https.py
+++ b/common/comms/common_https.py
@@ -43,6 +43,9 @@ class CommonHttps(object):
         if not validate_cert:
             logger.warning("Server certificate validation has been disabled.")
 
+        if ca_certs is None:
+            ca_certs = "/etc/pki/tls/certs/ca-certificates.crt"
+
         response = await httpclient.AsyncHTTPClient().fetch(url,
                                                             raise_error=raise_error_response,
                                                             method=method,

--- a/common/comms/tests/test_common_https.py
+++ b/common/comms/tests/test_common_https.py
@@ -67,3 +67,29 @@ class TestCommonHttps(TestCase):
                                           proxy_port=None)
 
             self.assertIs(actual_response, return_value, "Expected content should be returned.")
+
+    @async_test
+    async def test_make_request_with_no_cert(self):
+        with patch.object(httpclient.AsyncHTTPClient(), "fetch") as mock_fetch:
+            return_value = Mock()
+            mock_fetch.return_value = awaitable(return_value)
+
+            actual_response = await CommonHttps.make_request(url=URL, method=METHOD, headers=HEADERS, body=BODY,
+                                                             client_cert=CLIENT_CERT, client_key=CLIENT_KEY,
+                                                             ca_certs=None, validate_cert=False,
+                                                             http_proxy_host=HTTP_PROXY_HOST,
+                                                             http_proxy_port=HTTP_PROXY_PORT)
+
+            mock_fetch.assert_called_with(URL,
+                                          raise_error=True,
+                                          method=METHOD,
+                                          body=BODY,
+                                          headers=HEADERS,
+                                          client_cert=CLIENT_CERT,
+                                          client_key=CLIENT_KEY,
+                                          ca_certs=CA_CERTS,
+                                          validate_cert=False,
+                                          proxy_host=HTTP_PROXY_HOST,
+                                          proxy_port=HTTP_PROXY_PORT)
+
+            self.assertIs(actual_response, return_value, "Expected content should be returned.")

--- a/common/comms/tests/test_common_https.py
+++ b/common/comms/tests/test_common_https.py
@@ -69,8 +69,12 @@ class TestCommonHttps(TestCase):
             self.assertIs(actual_response, return_value, "Expected content should be returned.")
 
     @async_test
-    async def test_make_request_with_no_cert(self):
-        with patch.object(httpclient.AsyncHTTPClient(), "fetch") as mock_fetch:
+    async def test_make_request_with_no_cacert_uses_ssl_default_verify_path_cafile(self):
+        import ssl
+        with patch.object(httpclient.AsyncHTTPClient(), "fetch") as mock_fetch, \
+            patch.object(ssl, 'get_default_verify_paths', return_value=ssl.DefaultVerifyPaths(
+                CA_CERTS, None, None, None, None, None
+            )):
             return_value = Mock()
             mock_fetch.return_value = awaitable(return_value)
 

--- a/common/comms/tests/test_common_https.py
+++ b/common/comms/tests/test_common_https.py
@@ -58,9 +58,9 @@ class TestCommonHttps(TestCase):
                                           method=METHOD,
                                           body=BODY,
                                           headers=HEADERS,
-                                          client_cert='/etc/pki/tls/certs/ca-certificates.crt',
+                                          client_cert=None,
                                           client_key=None,
-                                          ca_certs=None,
+                                          ca_certs='/etc/pki/tls/certs/ca-certificates.crt',
                                           validate_cert=True,
                                           proxy_host=None,
                                           proxy_port=None)

--- a/common/comms/tests/test_common_https.py
+++ b/common/comms/tests/test_common_https.py
@@ -5,6 +5,7 @@ from tornado import httpclient
 
 from comms.common_https import CommonHttps
 from utilities.test_utilities import async_test, awaitable
+from unittest.mock import ANY
 
 URL = "ABC.ABC"
 METHOD = "GET"
@@ -60,7 +61,7 @@ class TestCommonHttps(TestCase):
                                           headers=HEADERS,
                                           client_cert=None,
                                           client_key=None,
-                                          ca_certs='/etc/pki/tls/certs/ca-certificates.crt',
+                                          ca_certs=ANY,
                                           validate_cert=True,
                                           proxy_host=None,
                                           proxy_port=None)

--- a/common/comms/tests/test_common_https.py
+++ b/common/comms/tests/test_common_https.py
@@ -58,7 +58,7 @@ class TestCommonHttps(TestCase):
                                           method=METHOD,
                                           body=BODY,
                                           headers=HEADERS,
-                                          client_cert=None,
+                                          client_cert='/etc/pki/tls/certs/ca-certificates.crt',
                                           client_key=None,
                                           ca_certs=None,
                                           validate_cert=True,

--- a/mhs/common/mhs_common/routing/tests/test_sds_api_client.py
+++ b/mhs/common/mhs_common/routing/tests/test_sds_api_client.py
@@ -145,7 +145,7 @@ class TestSdsApiClient(unittest.TestCase):
                       method=HTTP_METHOD, body=None,
                       headers={'X-Correlation-ID': CORRELATION_ID, 'apikey': API_KEY},
                       client_cert=None, client_key=None,
-                      ca_certs=None, validate_cert=True, proxy_host=None,
+                      ca_certs='/etc/pki/tls/certs/ca-certificates.crt', validate_cert=True, proxy_host=None,
                       proxy_port=None)
                  for expected_url in expected_urls]
 

--- a/mhs/common/mhs_common/routing/tests/test_sds_api_client.py
+++ b/mhs/common/mhs_common/routing/tests/test_sds_api_client.py
@@ -5,6 +5,7 @@ import urllib.parse
 from pathlib import Path
 from unittest import mock
 from unittest.mock import call
+from unittest.mock import ANY
 
 from tornado import httpclient
 
@@ -145,7 +146,7 @@ class TestSdsApiClient(unittest.TestCase):
                       method=HTTP_METHOD, body=None,
                       headers={'X-Correlation-ID': CORRELATION_ID, 'apikey': API_KEY},
                       client_cert=None, client_key=None,
-                      ca_certs='/etc/pki/tls/certs/ca-certificates.crt', validate_cert=True, proxy_host=None,
+                      ca_certs=ANY, validate_cert=True, proxy_host=None,
                       proxy_port=None)
                  for expected_url in expected_urls]
 

--- a/mhs/common/mhs_common/routing/tests/test_spine_route_lookup_client.py
+++ b/mhs/common/mhs_common/routing/tests/test_spine_route_lookup_client.py
@@ -1,5 +1,6 @@
 import unittest
 from unittest import mock
+from unittest.mock import ANY
 
 from tornado import httpclient
 from utilities import test_utilities
@@ -43,7 +44,7 @@ class TestSpineRouteLookupClient(unittest.TestCase):
 
         self.assertEqual(EXPECTED_RESPONSE, endpoint_details)
         expected_url = self._build_url(path=ROUTING_PATH)
-        self._assert_http_client_called_with_expected_args(expected_url, ca_certs='/etc/pki/tls/certs/ca-certificates.crt')
+        self._assert_http_client_called_with_expected_args(expected_url, ca_certs=ANY)
 
     @test_utilities.async_test
     async def test_should_retrieve_endpoint_details_with_default_org_code(self):
@@ -54,7 +55,7 @@ class TestSpineRouteLookupClient(unittest.TestCase):
 
         self.assertEqual(EXPECTED_RESPONSE, endpoint_details)
         expected_url = self._build_url(path=ROUTING_PATH, org_code=SPINE_ORG_CODE)
-        self._assert_http_client_called_with_expected_args(expected_url, ca_certs='/etc/pki/tls/certs/ca-certificates.crt')
+        self._assert_http_client_called_with_expected_args(expected_url, ca_certs=ANY)
 
     @test_utilities.async_test
     async def test_should_pass_through_exception_if_raised_when_retrieving_endpoint_details(self):
@@ -88,7 +89,7 @@ class TestSpineRouteLookupClient(unittest.TestCase):
 
         expected_url = self._build_url(path=ROUTING_PATH)
         self._assert_http_client_called_with_expected_args(expected_url, proxy_host=HTTP_PROXY_HOST,
-                                                           proxy_port=HTTP_PROXY_PORT, ca_certs='/etc/pki/tls/certs/ca-certificates.crt')
+                                                           proxy_port=HTTP_PROXY_PORT, ca_certs=ANY)
 
     @test_utilities.async_test
     async def test_should_retrieve_reliability_details_if_given_org_code(self):
@@ -99,7 +100,7 @@ class TestSpineRouteLookupClient(unittest.TestCase):
 
         self.assertEqual(EXPECTED_RESPONSE, endpoint_details)
         expected_url = self._build_url(path=RELIABILITY_PATH)
-        self._assert_http_client_called_with_expected_args(expected_url, ca_certs='/etc/pki/tls/certs/ca-certificates.crt')
+        self._assert_http_client_called_with_expected_args(expected_url, ca_certs=ANY)
 
     @test_utilities.async_test
     async def test_should_retrieve_reliability_details_with_default_org_code(self):
@@ -110,7 +111,7 @@ class TestSpineRouteLookupClient(unittest.TestCase):
 
         self.assertEqual(EXPECTED_RESPONSE, endpoint_details)
         expected_url = self._build_url(path=RELIABILITY_PATH, org_code=SPINE_ORG_CODE)
-        self._assert_http_client_called_with_expected_args(expected_url, ca_certs='/etc/pki/tls/certs/ca-certificates.crt')
+        self._assert_http_client_called_with_expected_args(expected_url, ca_certs=ANY)
 
     @test_utilities.async_test
     async def test_should_pass_through_exception_if_raised_when_retrieving_reliability_details(self):
@@ -144,7 +145,7 @@ class TestSpineRouteLookupClient(unittest.TestCase):
 
         expected_url = self._build_url(path=RELIABILITY_PATH)
         self._assert_http_client_called_with_expected_args(expected_url, proxy_host=HTTP_PROXY_HOST,
-                                                           proxy_port=HTTP_PROXY_PORT, ca_certs='/etc/pki/tls/certs/ca-certificates.crt')
+                                                           proxy_port=HTTP_PROXY_PORT, ca_certs=ANY)
 
     def _given_http_client_returns_a_json_response(self):
         mock_response = mock.Mock()

--- a/mhs/common/mhs_common/routing/tests/test_spine_route_lookup_client.py
+++ b/mhs/common/mhs_common/routing/tests/test_spine_route_lookup_client.py
@@ -43,7 +43,7 @@ class TestSpineRouteLookupClient(unittest.TestCase):
 
         self.assertEqual(EXPECTED_RESPONSE, endpoint_details)
         expected_url = self._build_url(path=ROUTING_PATH)
-        self._assert_http_client_called_with_expected_args(expected_url)
+        self._assert_http_client_called_with_expected_args(expected_url, ca_certs='/etc/pki/tls/certs/ca-certificates.crt')
 
     @test_utilities.async_test
     async def test_should_retrieve_endpoint_details_with_default_org_code(self):
@@ -54,7 +54,7 @@ class TestSpineRouteLookupClient(unittest.TestCase):
 
         self.assertEqual(EXPECTED_RESPONSE, endpoint_details)
         expected_url = self._build_url(path=ROUTING_PATH, org_code=SPINE_ORG_CODE)
-        self._assert_http_client_called_with_expected_args(expected_url)
+        self._assert_http_client_called_with_expected_args(expected_url, ca_certs='/etc/pki/tls/certs/ca-certificates.crt')
 
     @test_utilities.async_test
     async def test_should_pass_through_exception_if_raised_when_retrieving_endpoint_details(self):
@@ -88,7 +88,7 @@ class TestSpineRouteLookupClient(unittest.TestCase):
 
         expected_url = self._build_url(path=ROUTING_PATH)
         self._assert_http_client_called_with_expected_args(expected_url, proxy_host=HTTP_PROXY_HOST,
-                                                           proxy_port=HTTP_PROXY_PORT)
+                                                           proxy_port=HTTP_PROXY_PORT, ca_certs='/etc/pki/tls/certs/ca-certificates.crt')
 
     @test_utilities.async_test
     async def test_should_retrieve_reliability_details_if_given_org_code(self):
@@ -99,7 +99,7 @@ class TestSpineRouteLookupClient(unittest.TestCase):
 
         self.assertEqual(EXPECTED_RESPONSE, endpoint_details)
         expected_url = self._build_url(path=RELIABILITY_PATH)
-        self._assert_http_client_called_with_expected_args(expected_url)
+        self._assert_http_client_called_with_expected_args(expected_url, ca_certs='/etc/pki/tls/certs/ca-certificates.crt')
 
     @test_utilities.async_test
     async def test_should_retrieve_reliability_details_with_default_org_code(self):
@@ -110,7 +110,7 @@ class TestSpineRouteLookupClient(unittest.TestCase):
 
         self.assertEqual(EXPECTED_RESPONSE, endpoint_details)
         expected_url = self._build_url(path=RELIABILITY_PATH, org_code=SPINE_ORG_CODE)
-        self._assert_http_client_called_with_expected_args(expected_url)
+        self._assert_http_client_called_with_expected_args(expected_url, ca_certs='/etc/pki/tls/certs/ca-certificates.crt')
 
     @test_utilities.async_test
     async def test_should_pass_through_exception_if_raised_when_retrieving_reliability_details(self):
@@ -144,7 +144,7 @@ class TestSpineRouteLookupClient(unittest.TestCase):
 
         expected_url = self._build_url(path=RELIABILITY_PATH)
         self._assert_http_client_called_with_expected_args(expected_url, proxy_host=HTTP_PROXY_HOST,
-                                                           proxy_port=HTTP_PROXY_PORT)
+                                                           proxy_port=HTTP_PROXY_PORT, ca_certs='/etc/pki/tls/certs/ca-certificates.crt')
 
     def _given_http_client_returns_a_json_response(self):
         mock_response = mock.Mock()

--- a/mhs/outbound/main.py
+++ b/mhs/outbound/main.py
@@ -28,7 +28,7 @@ def configure_http_client():
     """
     Configure Tornado to use the curl HTTP client.
     """
-    tornado.httpclient.AsyncHTTPClient.configure('tornado.simple_httpclient.SimpleAsyncHTTPClient')
+    tornado.httpclient.AsyncHTTPClient.configure('tornado.curl_httpclient.CurlAsyncHTTPClient')
 
 
 def initialise_workflows(transmission: outbound_transmission.OutboundTransmission, party_key: str,

--- a/mhs/outbound/main.py
+++ b/mhs/outbound/main.py
@@ -147,7 +147,7 @@ def main():
 
     configure_http_client()
 
-    if ssl.get_default_verify_paths().openssl_cafile is None:
+    if ssl.get_default_verify_paths().cafile is None:
         raise Exception("Unable to find MHS path to certificates.")
 
     routing_lookup_method = config.get_config('OUTBOUND_ROUTING_LOOKUP_METHOD', default='SPINE_ROUTE_LOOKUP')

--- a/mhs/outbound/main.py
+++ b/mhs/outbound/main.py
@@ -148,7 +148,7 @@ def main():
     configure_http_client()
 
     if ssl.get_default_verify_paths().cafile is None:
-        raise Exception("Unable to find MHS path to certificates.")
+        raise Exception("Unable to find path to root certificates using the OpenSSL library. This is required to communicate with SDS. Quitting.")
 
     routing_lookup_method = config.get_config('OUTBOUND_ROUTING_LOOKUP_METHOD', default='SPINE_ROUTE_LOOKUP')
     if routing_lookup_method == 'SPINE_ROUTE_LOOKUP':

--- a/mhs/outbound/main.py
+++ b/mhs/outbound/main.py
@@ -1,4 +1,5 @@
 import pathlib
+import ssl
 from typing import Dict
 
 import tornado.httpclient
@@ -145,6 +146,9 @@ def main():
     data_dir = pathlib.Path(definitions.ROOT_DIR) / "data"
 
     configure_http_client()
+
+    if ssl.get_default_verify_paths().openssl_cafile is None:
+        raise Exception("Unable to find MHS path to certificates.")
 
     routing_lookup_method = config.get_config('OUTBOUND_ROUTING_LOOKUP_METHOD', default='SPINE_ROUTE_LOOKUP')
     if routing_lookup_method == 'SPINE_ROUTE_LOOKUP':

--- a/mhs/outbound/main.py
+++ b/mhs/outbound/main.py
@@ -28,7 +28,7 @@ def configure_http_client():
     """
     Configure Tornado to use the curl HTTP client.
     """
-    tornado.httpclient.AsyncHTTPClient.configure('tornado.curl_httpclient.CurlAsyncHTTPClient')
+    tornado.httpclient.AsyncHTTPClient.configure('tornado.simple_httpclient.SimpleAsyncHTTPClient')
 
 
 def initialise_workflows(transmission: outbound_transmission.OutboundTransmission, party_key: str,

--- a/mhs/outbound/main.py
+++ b/mhs/outbound/main.py
@@ -102,6 +102,9 @@ def initialise_sds_api_client():
     sds_api_key = config.get_config('SDS_API_KEY')
     spine_org_code = config.get_config('SPINE_ORG_CODE')
 
+    if ssl.get_default_verify_paths().cafile is None:
+        raise Exception("Unable to find path to root certificates using the OpenSSL library. This is required to communicate with SDS. Quitting.")
+
     return sds_api_client.SdsApiClient(sds_url, sds_api_key, spine_org_code)
 
 
@@ -146,9 +149,6 @@ def main():
     data_dir = pathlib.Path(definitions.ROOT_DIR) / "data"
 
     configure_http_client()
-
-    if ssl.get_default_verify_paths().cafile is None:
-        raise Exception("Unable to find path to root certificates using the OpenSSL library. This is required to communicate with SDS. Quitting.")
 
     routing_lookup_method = config.get_config('OUTBOUND_ROUTING_LOOKUP_METHOD', default='SPINE_ROUTE_LOOKUP')
     if routing_lookup_method == 'SPINE_ROUTE_LOOKUP':


### PR DESCRIPTION
## What + Why

When testing the Adaptor in PTL, we noticed that the first Outbound request would return a successful response, and then all subsequent requests returned a 500. We narrowed the issue down to the tornado HTTP client reusing the last CA Bundle it was given if no CA Bundle was explicitly specified. After the first request, this meant that SDS requests were trying to validate the authenticity of the SDS API by using the NHS root certificates (because the last request made was to Spine).

To workaround this Tornado issue, this we've changed our `CommonHttps.make_request` method to explicitly specify the OpenSSL root CA bundle in the case that no bundle is provided. This should only affect the calls to the FHIR SDS API, as that's the only HTTP server we call that uses a standard certificate. Calls to Spine use the NHS certificates passed in as environment variables.

## Type of change

Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users. **No CHANGELOG entry required, as this fixes a bug in code which hasn't been released yet.**
