### PR TITLE
Fix JSONArgsRecommended docker build check

### DIFF
--- a/docker/inbound/Dockerfile
+++ b/docker/inbound/Dockerfile
@@ -23,4 +23,4 @@ RUN pipenv install --deploy --ignore-pipfile
 
 EXPOSE 443 80
 
-ENTRYPOINT pipenv run start
+ENTRYPOINT ["pipenv", "run", "start"]

--- a/docker/outbound/Dockerfile
+++ b/docker/outbound/Dockerfile
@@ -29,4 +29,4 @@ RUN mkdir -p /etc/pki/tls && ln -s /etc/ssl/certs /etc/pki/tls/certs && ln -s ca
 
 EXPOSE 80
 
-ENTRYPOINT pipenv run start
+ENTRYPOINT ["pipenv", "run", "start"]

--- a/docker/spineroutelookup/Dockerfile
+++ b/docker/spineroutelookup/Dockerfile
@@ -27,4 +27,4 @@ RUN pipenv install --deploy --ignore-pipfile
 
 EXPOSE 80
 
-ENTRYPOINT pipenv run start
+ENTRYPOINT ["pipenv", "run", "start"]


### PR DESCRIPTION
## Why

Side effect of which is that PID1 is now pipenv instead of sh.

See also:
https://docs.docker.com/reference/build-checks/json-args-recommended/

## Type of change

Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
