### PR TITLE
Ask pystache to escape the attachment description for outbound

### DIFF
--- a/mhs/common/data/templates/ebxml_request.mustache
+++ b/mhs/common/data/templates/ebxml_request.mustache
@@ -43,7 +43,7 @@ Content-Transfer-Encoding: 8bit
             <eb:Description xml:lang="en">{{description}}</eb:Description>
         </eb:Reference>{{/attachments}}{{#external_attachments}}
         <eb:Reference{{#document_id}} eb:id="{{document_id}}"{{/document_id}} xlink:href="mid:{{message_id}}">
-            <eb:Description xml:lang="en">{{{description}}}</eb:Description>
+            <eb:Description xml:lang="en">{{description}}</eb:Description>
         </eb:Reference>{{/external_attachments}}
     </eb:Manifest>
 </SOAP:Body>

--- a/mhs/common/data/templates/ebxml_request.mustache
+++ b/mhs/common/data/templates/ebxml_request.mustache
@@ -40,7 +40,7 @@ Content-Transfer-Encoding: 8bit
             <hl7ebxml:Payload style="HL7" encoding="XML" version="3.0"/>
         </eb:Reference>{{#attachments}}
         <eb:Reference{{#document_id}} eb:id="{{document_id}}"{{/document_id}} xlink:href="cid:{{content_id}}">
-            <eb:Description xml:lang="en">{{{description}}}</eb:Description>
+            <eb:Description xml:lang="en">{{description}}</eb:Description>
         </eb:Reference>{{/attachments}}{{#external_attachments}}
         <eb:Reference{{#document_id}} eb:id="{{document_id}}"{{/document_id}} xlink:href="mid:{{message_id}}">
             <eb:Description xml:lang="en">{{{description}}}</eb:Description>

--- a/mhs/common/mhs_common/messages/tests/expected_messages/ebxml_request_one_attachment.xml
+++ b/mhs/common/mhs_common/messages/tests/expected_messages/ebxml_request_one_attachment.xml
@@ -34,7 +34,7 @@ Content-Transfer-Encoding: 8bit
             <hl7ebxml:Payload style="HL7" encoding="XML" version="3.0"/>
         </eb:Reference>
         <eb:Reference xlink:href="cid:8F1D7DE1-02AB-48D7-A797-A947B09F347F@spine.nhs.uk">
-            <eb:Description xml:lang="en">Some description</eb:Description>
+            <eb:Description xml:lang="en">Some A&amp;E description</eb:Description>
         </eb:Reference>
     </eb:Manifest>
 </SOAP:Body>

--- a/mhs/common/mhs_common/messages/tests/expected_messages/ebxml_request_one_external_attachment.xml
+++ b/mhs/common/mhs_common/messages/tests/expected_messages/ebxml_request_one_external_attachment.xml
@@ -33,15 +33,9 @@ Content-Transfer-Encoding: 8bit
             <eb:Description xml:lang="en">HL7 payload</eb:Description>
             <hl7ebxml:Payload style="HL7" encoding="XML" version="3.0"/>
         </eb:Reference>
-		<eb:Reference eb:id="8681AF4F-E577-4C8D-A2CE-43CABE3D5FB4" xlink:href="mid:8F1D7DE1-02AB-48D7-A797-A947B09F347F@spine.nhs.uk">
-			<eb:Description xml:lang="en">
-				Filename="8F1D7DE1-02AB-48D7-A797-A947B09F347F.txt"
-				ContentType=text/plain
-				Compressed=No
-				LargeAttachment=No
-				OriginalBase64=Yes
-			</eb:Description>
-		</eb:Reference>
+        <eb:Reference eb:id="8681AF4F-E577-4C8D-A2CE-43CABE3D5FB4" xlink:href="mid:8F1D7DE1-02AB-48D7-A797-A947B09F347F@spine.nhs.uk">
+            <eb:Description xml:lang="en">Filename=&quot;8F1D7DE1-A&amp;E-48D7-A797-A947B09F347F.txt&quot; ContentType=text/plain Compressed=No LargeAttachment=No OriginalBase64=Yes</eb:Description>
+        </eb:Reference>
     </eb:Manifest>
 </SOAP:Body>
 </SOAP:Envelope>
@@ -52,10 +46,4 @@ Content-Type: text/xml; charset=UTF-8
 Content-Transfer-Encoding: 8bit
 
 <QUPA_IN000006UK02 xmlns="urn:hl7-org:v3"></QUPA_IN000006UK02>
-----=_MIME-Boundary
-Content-Id: <8F1D7DE1-02AB-48D7-A797-A947B09F347F@spine.nhs.uk>
-Content-Type: text/plain
-Content-Transfer-Encoding: 8bit
-
-Some payload
 ----=_MIME-Boundary--

--- a/mhs/common/mhs_common/messages/tests/expected_messages/ebxml_request_one_external_attachment.xml
+++ b/mhs/common/mhs_common/messages/tests/expected_messages/ebxml_request_one_external_attachment.xml
@@ -33,8 +33,14 @@ Content-Transfer-Encoding: 8bit
             <eb:Description xml:lang="en">HL7 payload</eb:Description>
             <hl7ebxml:Payload style="HL7" encoding="XML" version="3.0"/>
         </eb:Reference>
-        <eb:Reference eb:id="8681AF4F-E577-4C8D-A2CE-43CABE3D5FB4" xlink:href="mid:8F1D7DE1-02AB-48D7-A797-A947B09F347F@spine.nhs.uk">
-            <eb:Description xml:lang="en">Filename=&quot;8F1D7DE1-A&amp;E-48D7-A797-A947B09F347F.txt&quot; ContentType=text/plain Compressed=No LargeAttachment=No OriginalBase64=Yes</eb:Description>
+		<eb:Reference eb:id="8681AF4F-E577-4C8D-A2CE-43CABE3D5FB4" xlink:href="mid:8F1D7DE1-02AB-48D7-A797-A947B09F347F@spine.nhs.uk">
+            <eb:Description xml:lang="en">
+				Filename=&quot;8F1D7DE1-A&amp;E-48D7-A797-A947B09F347F.txt&quot;
+				ContentType=text/plain
+				Compressed=No
+				LargeAttachment=No
+				OriginalBase64=Yes
+			</eb:Description>
         </eb:Reference>
     </eb:Manifest>
 </SOAP:Body>

--- a/mhs/common/mhs_common/messages/tests/expected_messages/ebxml_request_one_external_attachment.xml
+++ b/mhs/common/mhs_common/messages/tests/expected_messages/ebxml_request_one_external_attachment.xml
@@ -33,14 +33,8 @@ Content-Transfer-Encoding: 8bit
             <eb:Description xml:lang="en">HL7 payload</eb:Description>
             <hl7ebxml:Payload style="HL7" encoding="XML" version="3.0"/>
         </eb:Reference>
-		<eb:Reference eb:id="8681AF4F-E577-4C8D-A2CE-43CABE3D5FB4" xlink:href="mid:8F1D7DE1-02AB-48D7-A797-A947B09F347F@spine.nhs.uk">
-            <eb:Description xml:lang="en">
-				Filename=&quot;8F1D7DE1-A&amp;E-48D7-A797-A947B09F347F.txt&quot;
-				ContentType=text/plain
-				Compressed=No
-				LargeAttachment=No
-				OriginalBase64=Yes
-			</eb:Description>
+        <eb:Reference eb:id="8681AF4F-E577-4C8D-A2CE-43CABE3D5FB4" xlink:href="mid:8F1D7DE1-02AB-48D7-A797-A947B09F347F@spine.nhs.uk">
+            <eb:Description xml:lang="en">Filename=&quot;8F1D7DE1-A&amp;E-48D7-A797-A947B09F347F.txt&quot; ContentType=text/plain Compressed=No LargeAttachment=No OriginalBase64=Yes</eb:Description>
         </eb:Reference>
     </eb:Manifest>
 </SOAP:Body>

--- a/mhs/common/mhs_common/messages/tests/test_ebxml_request_envelope.py
+++ b/mhs/common/mhs_common/messages/tests/test_ebxml_request_envelope.py
@@ -100,7 +100,7 @@ class TestEbxmlRequestEnvelope(test_ebxml_envelope.BaseTestEbxmlEnvelope):
         message_dictionary[ebxml_request_envelope.ATTACHMENTS] = [{
             ebxml_request_envelope.ATTACHMENT_CONTENT_TYPE: 'text/plain',
             ebxml_request_envelope.ATTACHMENT_BASE64: False,
-            ebxml_request_envelope.ATTACHMENT_DESCRIPTION: 'Some description',
+            ebxml_request_envelope.ATTACHMENT_DESCRIPTION: 'Some A&E description',
             ebxml_request_envelope.ATTACHMENT_PAYLOAD: 'Some payload',
             ebxml_request_envelope.ATTACHMENT_DOCUMENT_ID: []
         }]

--- a/mhs/common/mhs_common/messages/tests/test_ebxml_request_envelope.py
+++ b/mhs/common/mhs_common/messages/tests/test_ebxml_request_envelope.py
@@ -118,6 +118,33 @@ class TestEbxmlRequestEnvelope(test_ebxml_envelope.BaseTestEbxmlEnvelope):
 
     @patch.object(message_utilities, "get_timestamp")
     @patch.object(message_utilities, "get_uuid")
+    def test_serialize_with_one_external_attachment(self, mock_get_uuid, mock_get_timestamp):
+        self.maxDiff = None
+        mock_get_uuid.side_effect = ["5BB171D4-53B2-4986-90CF-428BE6D157F5", test_ebxml_envelope.MOCK_UUID]
+        mock_get_timestamp.return_value = test_ebxml_envelope.MOCK_TIMESTAMP
+
+        message_dictionary = get_test_message_dictionary()
+        message_dictionary[ebxml_request_envelope.EXTERNAL_ATTACHMENTS] = [{
+            ebxml_envelope.EXTERNAL_ATTACHMENT_DOCUMENT_ID: '8681AF4F-E577-4C8D-A2CE-43CABE3D5FB4',
+            ebxml_envelope.EXTERNAL_ATTACHMENT_MESSAGE_ID: '8F1D7DE1-02AB-48D7-A797-A947B09F347F@spine.nhs.uk',
+            ebxml_envelope.EXTERNAL_ATTACHMENT_DESCRIPTION: 'Filename="8F1D7DE1-A&E-48D7-A797-A947B09F347F.txt" ContentType=text/plain Compressed=No LargeAttachment=No OriginalBase64=Yes',
+            ebxml_envelope.EXTERNAL_ATTACHMENT_TITLE: '"9F1D7DE1-02AB-48D7-A797-A947B09F347F.txt"'
+        }]
+        message_dictionary[ebxml_request_envelope.ATTACHMENTS] = []
+        envelope = ebxml_request_envelope.EbxmlRequestEnvelope(message_dictionary)
+
+        message_id, http_headers, message = envelope.serialize()
+
+        normalized_expected_message = self._get_expected_file_string('ebxml_request_one_external_attachment.xml')
+        normalized_message = file_utilities.normalize_line_endings(message)
+
+        self.assertEqual(test_ebxml_envelope.MOCK_UUID, message_id)
+        self.assertEqual(EXPECTED_HTTP_HEADERS, http_headers)
+        self.assertEqual(normalized_expected_message, normalized_message)
+
+
+    @patch.object(message_utilities, "get_timestamp")
+    @patch.object(message_utilities, "get_uuid")
     def test_serialize_with_one_attachment_with_document_id(self, mock_get_uuid, mock_get_timestamp):
         mock_get_uuid.side_effect = ["8F1D7DE1-02AB-48D7-A797-A947B09F347F", test_ebxml_envelope.MOCK_UUID]
         mock_get_timestamp.return_value = test_ebxml_envelope.MOCK_TIMESTAMP


### PR DESCRIPTION
⚠️ Before merging this needs some careful thought on how to perform E2E testing, and roll this out safely to downstream consumers ⚠️ 

## What

Pystache will use cgi.escape internally to map the following chars:
  - `<` -> `&lt;`
  - `>` -> `&rt;`
  - `&` -> `&amp;`

## Why

Performing this will allow inbound descriptions to include these characters within the JSON, and result in valid XML being generated by the adaptor.

## Type of change

Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
