### PR TITLE
Upgrade Python from 3.9 to 3.11

### DIFF
--- a/SETUP.MD
+++ b/SETUP.MD
@@ -29,9 +29,9 @@ ___
 ---
 ### 3. Terminal actions
 
-Install ``Python 3.9``:
+Install ``Python 3.11``:
 ```shell
-  brew install python@3.9
+  brew install python@3.11
   brew install pipenv
 ```
 
@@ -46,9 +46,9 @@ Note: If you have ``pyenv`` already installed, ``pipenv`` will get the global se
     * `mhs/outbound`
 
 
-**Install dependencies for `Python 3.9` for each:**
+**Install dependencies for `Python 3.11` for each:**
 ```shell
-  pipenv --python 3.9
+  pipenv --python 3.11
 ```
 
 ---

--- a/common/Pipfile
+++ b/common/Pipfile
@@ -17,7 +17,7 @@ aioboto3 = "~=11.3.1"
 motor = "~=3.5.1"
 
 [requires]
-python_version = "3.9"
+python_version = "3.11"
 
 [scripts]
 unittests = 'python -m xmlrunner -o test-reports -v'

--- a/common/Pipfile.lock
+++ b/common/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "dcf811740caf2c360ad2b32ec7441b8d20744e818e4b796ee166086d9b9433d5"
+            "sha256": "11ff43b9bfc67994b27648be106c7298f6cb7a403faa06b727f68456084db44c"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.9"
+            "python_version": "3.11"
         },
         "sources": [
             {
@@ -141,14 +141,6 @@
             ],
             "markers": "python_version >= '3.9'",
             "version": "==1.3.2"
-        },
-        "async-timeout": {
-            "hashes": [
-                "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c",
-                "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==5.0.1"
         },
         "attrs": {
             "hashes": [
@@ -360,14 +352,6 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==3.10"
-        },
-        "importlib-metadata": {
-            "hashes": [
-                "sha256:45e54197d28b7a7f1559e60b95e7c567032b602131fbd588f1497f47880aa68b",
-                "sha256:71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==8.5.0"
         },
         "isodate": {
             "hashes": [
@@ -849,14 +833,6 @@
             "markers": "python_version >= '3.8'",
             "version": "==6.4.2"
         },
-        "typing-extensions": {
-            "hashes": [
-                "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
-                "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==4.12.2"
-        },
         "urllib3": {
             "hashes": [
                 "sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e",
@@ -1023,14 +999,6 @@
             ],
             "markers": "python_version >= '3.9'",
             "version": "==1.18.3"
-        },
-        "zipp": {
-            "hashes": [
-                "sha256:2c9958f6430a2040341a52eb608ed6dd93ef4392e02ffe219417c1b28b5dd1f4",
-                "sha256:ac1bbe05fd2991f160ebce24ffbac5f6d11d83dc90891255885223d42b3cd931"
-            ],
-            "markers": "python_version >= '3.9'",
-            "version": "==3.21.0"
         }
     },
     "develop": {

--- a/component-test.Dockerfile
+++ b/component-test.Dockerfile
@@ -1,6 +1,6 @@
 # This file is used to run component tests on CI. Once the component tests don't rely on the common project, this
 # file can be moved to a sub directory.
-FROM python:3.9-slim-bookworm
+FROM python:3.11-slim-bookworm
 
 RUN apt-get update && \
     apt-get install -y build-essential libssl-dev swig pkg-config libxml2-dev libxslt-dev python3-dev libffi-dev
@@ -15,7 +15,7 @@ WORKDIR /test/integration-tests/integration_tests
 ENV PYTHONPATH "${PYTHONPATH}:/test/mhs/common"
 ENV PYTHONPATH "${PYTHONPATH}:/test/common"
 
-RUN pipenv --python 3.9
+RUN pipenv --python 3.11
 RUN pipenv install --dev --deploy --ignore-pipfile
 
 ENTRYPOINT ["pipenv", "run", "componenttests"]

--- a/docker/inbound/Dockerfile
+++ b/docker/inbound/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim-bookworm AS base
+FROM python:3.11-slim-bookworm AS base
 
 RUN apt-get update && \
     apt-get install -y build-essential libssl-dev swig pkg-config libxml2-dev libxslt-dev python3-dev libffi-dev
@@ -18,7 +18,7 @@ WORKDIR /usr/src/app/mhs/inbound
 ENV PYTHONPATH "${PYTHONPATH}:/usr/src/app/mhs/common"
 ENV PYTHONPATH "${PYTHONPATH}:/usr/src/app/common"
 
-RUN pipenv --python 3.9
+RUN pipenv --python 3.11
 RUN pipenv install --deploy --ignore-pipfile
 
 EXPOSE 443 80

--- a/docker/outbound/Dockerfile
+++ b/docker/outbound/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim-bookworm AS base
+FROM python:3.11-slim-bookworm AS base
 
 RUN apt-get update && \
     apt-get install -y build-essential libssl-dev swig pkg-config libxml2-dev libxslt-dev python3-dev libffi-dev
@@ -21,7 +21,7 @@ WORKDIR /usr/src/app/mhs/outbound
 ENV PYTHONPATH "${PYTHONPATH}:/usr/src/app/mhs/common"
 ENV PYTHONPATH "${PYTHONPATH}:/usr/src/app/common"
 
-RUN pipenv --python 3.9
+RUN pipenv --python 3.11
 RUN pipenv install --deploy --ignore-pipfile
 
 # PYCURL expects certificate to live in /etc/pki/tls, Debian is providing the cert in ssl/certs

--- a/docker/spineroutelookup/Dockerfile
+++ b/docker/spineroutelookup/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim-bookworm AS base
+FROM python:3.11-slim-bookworm AS base
 
 RUN apt-get update && \
     apt-get install -y build-essential libssl-dev swig pkg-config libxml2-dev libxslt-dev python3-dev libffi-dev
@@ -22,7 +22,7 @@ ENV PYTHONPATH "${PYTHONPATH}:/usr/src/app/common"
 
 WORKDIR /usr/src/app/mhs/spineroutelookup
 
-RUN pipenv --python 3.9
+RUN pipenv --python 3.11
 RUN pipenv install --deploy --ignore-pipfile
 
 EXPOSE 80

--- a/examples/SCR/Pipfile
+++ b/examples/SCR/Pipfile
@@ -10,7 +10,7 @@ scr = {editable = true,path = "."}
 integration-adaptors-common = {editable = true, path = "../../common"}
 
 [requires]
-python_version = "3.9"
+python_version = "3.11"
 
 [scripts]
 unittests = "python -m unittest -v"

--- a/examples/SCR/Pipfile.lock
+++ b/examples/SCR/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "44ca1d9025828894688c8fc4d082157c7332ed03bae10988de2473039c8dafc9"
+            "sha256": "e19d42c356851ede7949c7de8883ea798fa4b2932d6eba204dcfd13d639da7db"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.9"
+            "python_version": "3.11"
         },
         "sources": [
             {
@@ -140,14 +140,6 @@
             ],
             "markers": "python_version >= '3.9'",
             "version": "==1.3.2"
-        },
-        "async-timeout": {
-            "hashes": [
-                "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c",
-                "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==5.0.1"
         },
         "attrs": {
             "hashes": [
@@ -359,14 +351,6 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==3.10"
-        },
-        "importlib-metadata": {
-            "hashes": [
-                "sha256:45e54197d28b7a7f1559e60b95e7c567032b602131fbd588f1497f47880aa68b",
-                "sha256:71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==8.5.0"
         },
         "integration-adaptors-common": {
             "editable": true,
@@ -850,14 +834,6 @@
             "markers": "python_version >= '3.8'",
             "version": "==6.4.2"
         },
-        "typing-extensions": {
-            "hashes": [
-                "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
-                "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==4.12.2"
-        },
         "urllib3": {
             "hashes": [
                 "sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e",
@@ -1024,14 +1000,6 @@
             ],
             "markers": "python_version >= '3.9'",
             "version": "==1.18.3"
-        },
-        "zipp": {
-            "hashes": [
-                "sha256:2c9958f6430a2040341a52eb608ed6dd93ef4392e02ffe219417c1b28b5dd1f4",
-                "sha256:ac1bbe05fd2991f160ebce24ffbac5f6d11d83dc90891255885223d42b3cd931"
-            ],
-            "markers": "python_version >= '3.9'",
-            "version": "==3.21.0"
         }
     },
     "develop": {}

--- a/examples/SCRWebService/Pipfile
+++ b/examples/SCRWebService/Pipfile
@@ -14,7 +14,7 @@ tornado = "~=6.4.1"
 integration-adaptors-common = {editable = true, path = "../../common"}
 
 [requires]
-python_version = "3.9"
+python_version = "3.11"
 
 [scripts]
 unittests = 'python -m xmlrunner -o test-reports -v'

--- a/examples/SCRWebService/Pipfile.lock
+++ b/examples/SCRWebService/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b1682593029245eb9ce033789384d45c7d2e6202236507a20058e92eb91d0b49"
+            "sha256": "c4daef5ea75ed8fabcbc5f345f64ec48d3a0149cf596d1cbf3b08a980d55f38b"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.9"
+            "python_version": "3.11"
         },
         "sources": [
             {
@@ -140,14 +140,6 @@
             ],
             "markers": "python_version >= '3.9'",
             "version": "==1.3.2"
-        },
-        "async-timeout": {
-            "hashes": [
-                "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c",
-                "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==5.0.1"
         },
         "attrs": {
             "hashes": [
@@ -478,14 +470,6 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==3.10"
-        },
-        "importlib-metadata": {
-            "hashes": [
-                "sha256:45e54197d28b7a7f1559e60b95e7c567032b602131fbd588f1497f47880aa68b",
-                "sha256:71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==8.5.0"
         },
         "integration-adaptors-common": {
             "editable": true,
@@ -979,14 +963,6 @@
             "markers": "python_version >= '3.8'",
             "version": "==6.4.2"
         },
-        "typing-extensions": {
-            "hashes": [
-                "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
-                "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==4.12.2"
-        },
         "urllib3": {
             "hashes": [
                 "sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e",
@@ -1153,14 +1129,6 @@
             ],
             "markers": "python_version >= '3.9'",
             "version": "==1.18.3"
-        },
-        "zipp": {
-            "hashes": [
-                "sha256:2c9958f6430a2040341a52eb608ed6dd93ef4392e02ffe219417c1b28b5dd1f4",
-                "sha256:ac1bbe05fd2991f160ebce24ffbac5f6d11d83dc90891255885223d42b3cd931"
-            ],
-            "markers": "python_version >= '3.9'",
-            "version": "==3.21.0"
         }
     },
     "develop": {

--- a/examples/supplier-example/Pipfile
+++ b/examples/supplier-example/Pipfile
@@ -12,7 +12,7 @@ flask = "~=3.0.3"
 requests = "~=2.32.3"
 
 [requires]
-python_version = "3.9"
+python_version = "3.11"
 
 [scripts]
 server = "python runserver.py"

--- a/integration-tests/fake_spine/Dockerfile
+++ b/integration-tests/fake_spine/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim-bookworm
+FROM python:3.11-slim-bookworm
 RUN apt-get update
 RUN apt-get install -y \
     build-essential \
@@ -14,7 +14,7 @@ WORKDIR /usr/src/app/mhs/fakespine
 COPY integration-tests/fake_spine/Pipfile /usr/src/app
 COPY integration-tests/fake_spine/Pipfile.lock /usr/src/app
 
-RUN pipenv --python 3.9
+RUN pipenv --python 3.11
 RUN pipenv run uninstall_setuptools
 RUN pipenv run install_setuptools
 RUN pipenv install --deploy --ignore-pipfile

--- a/integration-tests/fake_spine/Pipfile
+++ b/integration-tests/fake_spine/Pipfile
@@ -11,7 +11,7 @@ pystache = "~=0.6"
 integration-adaptors-common = {editable = true, path = "../../common"}
 
 [requires]
-python_version = "3.9"
+python_version = "3.11"
 
 [scripts]
 start = "python main.py"

--- a/integration-tests/fake_spine/Pipfile.lock
+++ b/integration-tests/fake_spine/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "db488e3efd679aee22bcdadb3ad923203ed451db6efc30f58c4b4f69ccf913fd"
+            "sha256": "0ebf2a8c467098c2db9e93e87d220c9a6b1760fc7c20eba6084884c367347fa4"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.9"
+            "python_version": "3.11"
         },
         "sources": [
             {
@@ -140,14 +140,6 @@
             ],
             "markers": "python_version >= '3.9'",
             "version": "==1.3.2"
-        },
-        "async-timeout": {
-            "hashes": [
-                "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c",
-                "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==5.0.1"
         },
         "attrs": {
             "hashes": [
@@ -359,14 +351,6 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==3.10"
-        },
-        "importlib-metadata": {
-            "hashes": [
-                "sha256:45e54197d28b7a7f1559e60b95e7c567032b602131fbd588f1497f47880aa68b",
-                "sha256:71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==8.5.0"
         },
         "integration-adaptors-common": {
             "editable": true,
@@ -848,14 +832,6 @@
             "markers": "python_version >= '3.8'",
             "version": "==6.4.2"
         },
-        "typing-extensions": {
-            "hashes": [
-                "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
-                "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==4.12.2"
-        },
         "urllib3": {
             "hashes": [
                 "sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e",
@@ -1022,14 +998,6 @@
             ],
             "markers": "python_version >= '3.9'",
             "version": "==1.18.3"
-        },
-        "zipp": {
-            "hashes": [
-                "sha256:2c9958f6430a2040341a52eb608ed6dd93ef4392e02ffe219417c1b28b5dd1f4",
-                "sha256:ac1bbe05fd2991f160ebce24ffbac5f6d11d83dc90891255885223d42b3cd931"
-            ],
-            "markers": "python_version >= '3.9'",
-            "version": "==3.21.0"
         }
     },
     "develop": {}

--- a/integration-tests/fake_spineroutelookup/Dockerfile
+++ b/integration-tests/fake_spineroutelookup/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim-bookworm AS base
+FROM python:3.11-slim-bookworm AS base
 
 WORKDIR /app
 

--- a/integration-tests/fake_spineroutelookup/Pipfile
+++ b/integration-tests/fake_spineroutelookup/Pipfile
@@ -9,7 +9,7 @@ verify_ssl = true
 tornado = "*"
 
 [requires]
-python_version = "3.9"
+python_version = "3.11"
 
 [scripts]
 start = "python main.py"

--- a/integration-tests/fake_spineroutelookup/Pipfile.lock
+++ b/integration-tests/fake_spineroutelookup/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6e6166901765ef042ecb82ae896cd6a972a93acb076056f38f0d51c17f5579b9"
+            "sha256": "7ec5a3c239c35b30a3205060eb524560a40a6633c97018118165aab623ba3601"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.9"
+            "python_version": "3.11"
         },
         "sources": [
             {

--- a/integration-tests/integration_tests/Pipfile
+++ b/integration-tests/integration_tests/Pipfile
@@ -17,7 +17,7 @@ dpath = "~=2.2.0"
 integration-adaptors-common = {editable = true, path = "../../common"}
 
 [requires]
-python_version = "3.9"
+python_version = "3.11"
 
 [scripts]
 inttests = 'python -m xmlrunner discover -o test-reports -p "int_*" -v'

--- a/integration-tests/integration_tests/Pipfile.lock
+++ b/integration-tests/integration_tests/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a49fb91df0fdd1e7fc0951c5c29658b16d91b5846fc88e81a9ecbbd0427b2f9a"
+            "sha256": "7ad19ac4a3cc6865237c70ff659c08a628531abb4a103743162b130af2513199"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.9"
+            "python_version": "3.11"
         },
         "sources": [
             {
@@ -141,14 +141,6 @@
             ],
             "markers": "python_version >= '3.9'",
             "version": "==1.3.2"
-        },
-        "async-timeout": {
-            "hashes": [
-                "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c",
-                "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==5.0.1"
         },
         "attrs": {
             "hashes": [
@@ -497,14 +489,6 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==3.10"
-        },
-        "importlib-metadata": {
-            "hashes": [
-                "sha256:45e54197d28b7a7f1559e60b95e7c567032b602131fbd588f1497f47880aa68b",
-                "sha256:71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==8.5.0"
         },
         "integration-adaptors-common": {
             "editable": true,
@@ -1013,14 +997,6 @@
             "markers": "python_version >= '3.8'",
             "version": "==6.4.2"
         },
-        "typing-extensions": {
-            "hashes": [
-                "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
-                "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==4.12.2"
-        },
         "urllib3": {
             "hashes": [
                 "sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e",
@@ -1187,14 +1163,6 @@
             ],
             "markers": "python_version >= '3.9'",
             "version": "==1.18.3"
-        },
-        "zipp": {
-            "hashes": [
-                "sha256:2c9958f6430a2040341a52eb608ed6dd93ef4392e02ffe219417c1b28b5dd1f4",
-                "sha256:ac1bbe05fd2991f160ebce24ffbac5f6d11d83dc90891255885223d42b3cd931"
-            ],
-            "markers": "python_version >= '3.9'",
-            "version": "==3.21.0"
         }
     },
     "develop": {

--- a/mhs/common/Pipfile
+++ b/mhs/common/Pipfile
@@ -16,7 +16,7 @@ marshmallow = "~=3.21.3"
 integration-adaptors-common = {editable = true, path = "./../../common"}
 
 [requires]
-python_version = "3.9"
+python_version = "3.11"
 
 [scripts]
 unittests = 'python -m xmlrunner -o test-reports -v'

--- a/mhs/common/Pipfile.lock
+++ b/mhs/common/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3e2d78e4b9434b5015de0433bc5aaaf22c7e3831c3822d5f846fa3ba578da131"
+            "sha256": "b371a47e16dff477aff9b760873af7562fd2b33676e37c069fcb7818c0333fec"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.9"
+            "python_version": "3.11"
         },
         "sources": [
             {
@@ -141,14 +141,6 @@
             ],
             "markers": "python_version >= '3.9'",
             "version": "==1.3.2"
-        },
-        "async-timeout": {
-            "hashes": [
-                "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c",
-                "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==5.0.1"
         },
         "attrs": {
             "hashes": [
@@ -369,14 +361,6 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==3.10"
-        },
-        "importlib-metadata": {
-            "hashes": [
-                "sha256:45e54197d28b7a7f1559e60b95e7c567032b602131fbd588f1497f47880aa68b",
-                "sha256:71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==8.5.0"
         },
         "integration-adaptors-common": {
             "editable": true,
@@ -875,14 +859,6 @@
             "markers": "python_version >= '3.8'",
             "version": "==6.4.2"
         },
-        "typing-extensions": {
-            "hashes": [
-                "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
-                "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==4.12.2"
-        },
         "urllib3": {
             "hashes": [
                 "sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e",
@@ -1049,14 +1025,6 @@
             ],
             "markers": "python_version >= '3.9'",
             "version": "==1.18.3"
-        },
-        "zipp": {
-            "hashes": [
-                "sha256:2c9958f6430a2040341a52eb608ed6dd93ef4392e02ffe219417c1b28b5dd1f4",
-                "sha256:ac1bbe05fd2991f160ebce24ffbac5f6d11d83dc90891255885223d42b3cd931"
-            ],
-            "markers": "python_version >= '3.9'",
-            "version": "==3.21.0"
         }
     },
     "develop": {

--- a/mhs/inbound/Pipfile
+++ b/mhs/inbound/Pipfile
@@ -15,7 +15,7 @@ isodate = "~=0.6"
 update = "*"
 
 [requires]
-python_version = "3.9"
+python_version = "3.11"
 
 [scripts]
 unittests = 'python -m xmlrunner -o test-reports -v'

--- a/mhs/inbound/Pipfile.lock
+++ b/mhs/inbound/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d6831b3f26fe9c21bef1f64781a2cbdbd3d41b61d4a3f6a4f6d473578279580a"
+            "sha256": "24729ecd0410fd20f2d257f36172ff731e6ab928cf22f5e2ad228efd67d6b683"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.9"
+            "python_version": "3.11"
         },
         "sources": [
             {
@@ -140,14 +140,6 @@
             ],
             "markers": "python_version >= '3.9'",
             "version": "==1.3.2"
-        },
-        "async-timeout": {
-            "hashes": [
-                "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c",
-                "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==5.0.1"
         },
         "attrs": {
             "hashes": [
@@ -367,14 +359,6 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==3.10"
-        },
-        "importlib-metadata": {
-            "hashes": [
-                "sha256:45e54197d28b7a7f1559e60b95e7c567032b602131fbd588f1497f47880aa68b",
-                "sha256:71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==8.5.0"
         },
         "integration-adaptors-common": {
             "editable": true,
@@ -883,14 +867,6 @@
             "markers": "python_version >= '3.8'",
             "version": "==6.4.2"
         },
-        "typing-extensions": {
-            "hashes": [
-                "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
-                "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==4.12.2"
-        },
         "update": {
             "hashes": [
                 "sha256:a25522b4bf60e3e3c1a3ff3ca3a4f5a328ac4b8ff400fdc9614483147e313323"
@@ -1064,14 +1040,6 @@
             ],
             "markers": "python_version >= '3.9'",
             "version": "==1.18.3"
-        },
-        "zipp": {
-            "hashes": [
-                "sha256:2c9958f6430a2040341a52eb608ed6dd93ef4392e02ffe219417c1b28b5dd1f4",
-                "sha256:ac1bbe05fd2991f160ebce24ffbac5f6d11d83dc90891255885223d42b3cd931"
-            ],
-            "markers": "python_version >= '3.9'",
-            "version": "==3.21.0"
         }
     },
     "develop": {

--- a/mhs/outbound/Pipfile
+++ b/mhs/outbound/Pipfile
@@ -18,7 +18,7 @@ integration-adaptors-common = {editable = true, path = "./../../common"}
 pycurl = "~=7.43"
 
 [requires]
-python_version = "3.9"
+python_version = "3.11"
 
 [scripts]
 unittests = 'python -m xmlrunner -o test-reports -v'

--- a/mhs/outbound/Pipfile.lock
+++ b/mhs/outbound/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "41c9bd50494d72dd2913e314d0c9fdb9d5f21ca3c38ffe8a189400767dd3b282"
+            "sha256": "eb6e0b47c0b5c1b65ef711de4f2ec5a64d8f141f7ad58137e4d8755970188500"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.9"
+            "python_version": "3.11"
         },
         "sources": [
             {
@@ -140,14 +140,6 @@
             ],
             "markers": "python_version >= '3.9'",
             "version": "==1.3.2"
-        },
-        "async-timeout": {
-            "hashes": [
-                "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c",
-                "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==5.0.1"
         },
         "attrs": {
             "hashes": [
@@ -368,14 +360,6 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==3.10"
-        },
-        "importlib-metadata": {
-            "hashes": [
-                "sha256:45e54197d28b7a7f1559e60b95e7c567032b602131fbd588f1497f47880aa68b",
-                "sha256:71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==8.5.0"
         },
         "integration-adaptors-common": {
             "editable": true,
@@ -915,14 +899,6 @@
             "markers": "python_version >= '3.8'",
             "version": "==6.4.2"
         },
-        "typing-extensions": {
-            "hashes": [
-                "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
-                "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==4.12.2"
-        },
         "urllib3": {
             "hashes": [
                 "sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e",
@@ -1089,14 +1065,6 @@
             ],
             "markers": "python_version >= '3.9'",
             "version": "==1.18.3"
-        },
-        "zipp": {
-            "hashes": [
-                "sha256:2c9958f6430a2040341a52eb608ed6dd93ef4392e02ffe219417c1b28b5dd1f4",
-                "sha256:ac1bbe05fd2991f160ebce24ffbac5f6d11d83dc90891255885223d42b3cd931"
-            ],
-            "markers": "python_version >= '3.9'",
-            "version": "==3.21.0"
         }
     },
     "develop": {

--- a/mhs/spineroutelookup/Pipfile
+++ b/mhs/spineroutelookup/Pipfile
@@ -16,7 +16,7 @@ redis = "~=3.3"
 integration-adaptors-common = {editable = true, path = "./../../common"}
 
 [requires]
-python_version = "3.9"
+python_version = "3.11"
 
 [scripts]
 unittests = 'python -m xmlrunner -o test-reports -v'

--- a/mhs/spineroutelookup/Pipfile.lock
+++ b/mhs/spineroutelookup/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0a88efe85f795dcf9ee878c6bb7cfa9319ef62ad644861864304cec78db52f31"
+            "sha256": "f3a299e24d59a905dbbd8227c85b5671cd5eddaca1f39607ff7f77c285d753ea"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.9"
+            "python_version": "3.11"
         },
         "sources": [
             {
@@ -140,14 +140,6 @@
             ],
             "markers": "python_version >= '3.9'",
             "version": "==1.3.2"
-        },
-        "async-timeout": {
-            "hashes": [
-                "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c",
-                "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==5.0.1"
         },
         "attrs": {
             "hashes": [
@@ -368,14 +360,6 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==3.10"
-        },
-        "importlib-metadata": {
-            "hashes": [
-                "sha256:45e54197d28b7a7f1559e60b95e7c567032b602131fbd588f1497f47880aa68b",
-                "sha256:71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==8.5.0"
         },
         "integration-adaptors-common": {
             "editable": true,
@@ -904,14 +888,6 @@
             "markers": "python_version >= '3.8'",
             "version": "==6.4.2"
         },
-        "typing-extensions": {
-            "hashes": [
-                "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
-                "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==4.12.2"
-        },
         "urllib3": {
             "hashes": [
                 "sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e",
@@ -1078,14 +1054,6 @@
             ],
             "markers": "python_version >= '3.9'",
             "version": "==1.18.3"
-        },
-        "zipp": {
-            "hashes": [
-                "sha256:2c9958f6430a2040341a52eb608ed6dd93ef4392e02ffe219417c1b28b5dd1f4",
-                "sha256:ac1bbe05fd2991f160ebce24ffbac5f6d11d83dc90891255885223d42b3cd931"
-            ],
-            "markers": "python_version >= '3.9'",
-            "version": "==3.21.0"
         }
     },
     "develop": {

--- a/pipeline/packer/jenkins-worker/Dockerfile
+++ b/pipeline/packer/jenkins-worker/Dockerfile
@@ -17,13 +17,13 @@ RUN wget -O terraform.zip https://releases.hashicorp.com/terraform/0.12.31/terra
         unzip terraform.zip -d /usr/bin/ && \
         rm terraform.zip
 
-# Install Python 3.9
+# Install Python 3.11
 RUN apt-get update && apt-get install -y build-essential libreadline-gplv2-dev libncursesw5-dev libssl-dev libsqlite3-dev libgdbm-dev libc6-dev libbz2-dev uuid-dev zlib1g-dev libffi-dev swig pkg-config && \
-        wget -O python.tgz https://www.python.org/ftp/python/3.9.19/Python-3.9.19.tgz && \
+        wget -O python.tgz https://www.python.org/ftp/python/3.11.11/Python-3.11.11.tgz && \
         tar -xf python.tgz && rm python.tgz && \
-        cd Python-3.9.19 && \
+        cd Python-3.11.11 && \
         ./configure && make && make install && \
-        cd .. && rm -rf Python-3.9.19
+        cd .. && rm -rf Python-3.11.11
 
 # Install pipenv
 RUN pip3 install pipenv

--- a/pipeline/packer/jenkins-worker/README.md
+++ b/pipeline/packer/jenkins-worker/README.md
@@ -11,7 +11,7 @@ Usage:
    the ability to rollback.
 4. Run these commands, specifying the version you wish to publish as.
    ```shell
-   VERSION=0.6
+   VERSION=0.7
    REGISTRY="$(aws sts get-caller-identity --query 'Account' --output text).dkr.ecr.eu-west-2.amazonaws.com"
    aws ecr get-login-password --region eu-west-2 | docker login -u AWS --password-stdin $REGISTRY
    docker buildx build --platform linux/amd64 --tag $REGISTRY/jenkins-worker:$VERSION --push .

--- a/pipeline/scripts/check-target-group-health/Pipfile
+++ b/pipeline/scripts/check-target-group-health/Pipfile
@@ -10,7 +10,7 @@ boto3 = "*"
 requests = "*"
 
 [requires]
-python_version = "3.9"
+python_version = "3.11"
 
 [scripts]
 main = "python main.py"

--- a/pipeline/scripts/check-target-group-health/Pipfile.lock
+++ b/pipeline/scripts/check-target-group-health/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b16279f83539b94d3530b9606f858cf108eec55d33d4f47c49dca679f8c799df"
+            "sha256": "d89364d1fc7971ec5da9b200bb0c2cc601771234afa8d3c97f0fd45a09d30e42"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.9"
+            "python_version": "3.11"
         },
         "sources": [
             {
@@ -203,11 +203,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e",
-                "sha256:40c2dc0c681e47eb8f90e7e27bf6ff7df2e677421fd46756da1161c39ca70d32"
+                "sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac",
+                "sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.26.20"
+            "markers": "python_version >= '3.8'",
+            "version": "==2.2.3"
         }
     },
     "develop": {}


### PR DESCRIPTION
## Why

3.9 is end of life Oct 2025

Upgrading to 3.11 gives us two extra years of support

## Type of change

Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
