### PR TITLE
Switch from using `async_test` to `IsolatedAsyncioTestCase`

### DIFF
--- a/common/comms/tests/test_common_https.py
+++ b/common/comms/tests/test_common_https.py
@@ -1,10 +1,10 @@
-from unittest import TestCase
+from unittest import IsolatedAsyncioTestCase
 from unittest.mock import patch, Mock
 
 from tornado import httpclient
 
 from comms.common_https import CommonHttps
-from utilities.test_utilities import async_test, awaitable
+from utilities.test_utilities import awaitable
 from unittest.mock import ANY
 
 URL = "ABC.ABC"
@@ -18,9 +18,8 @@ HTTP_PROXY_HOST = "http_proxy"
 HTTP_PROXY_PORT = 3128
 
 
-class TestCommonHttps(TestCase):
+class TestCommonHttps(IsolatedAsyncioTestCase):
 
-    @async_test
     async def test_make_request(self):
         with patch.object(httpclient.AsyncHTTPClient(), "fetch") as mock_fetch:
             return_value = Mock()
@@ -46,7 +45,6 @@ class TestCommonHttps(TestCase):
 
             self.assertIs(actual_response, return_value, "Expected content should be returned.")
 
-    @async_test
     async def test_make_request_defaults(self):
         with patch.object(httpclient.AsyncHTTPClient(), "fetch") as mock_fetch:
             return_value = Mock()
@@ -68,7 +66,6 @@ class TestCommonHttps(TestCase):
 
             self.assertIs(actual_response, return_value, "Expected content should be returned.")
 
-    @async_test
     async def test_make_request_with_no_cacert_uses_ssl_default_verify_path_cafile(self):
         import ssl
         with patch.object(httpclient.AsyncHTTPClient(), "fetch") as mock_fetch, \

--- a/common/comms/tests/test_proton_queue_adaptor.py
+++ b/common/comms/tests/test_proton_queue_adaptor.py
@@ -2,7 +2,6 @@
 import unittest.mock
 
 import comms.proton_queue_adaptor
-import utilities.test_utilities
 
 TEST_UUID = "TEST UUID"
 TEST_MESSAGE = {'test': 'message'}
@@ -21,7 +20,7 @@ TEST_TTL = 100
 
 
 @unittest.mock.patch('utilities.message_utilities.get_uuid', new=lambda: TEST_UUID)
-class TestProtonQueueAdaptor(unittest.TestCase):
+class TestProtonQueueAdaptor(unittest.IsolatedAsyncioTestCase):
     """Class to contain tests for the ProtonQueueAdaptor functionality."""
 
     def setUp(self) -> None:
@@ -54,7 +53,6 @@ class TestProtonQueueAdaptor(unittest.TestCase):
 
     # TESTING SEND ASYNC METHOD
 
-    @utilities.test_utilities.async_test
     async def test_send_async_success(self):
         """Test happy path of send_async."""
         awaitable = self.service.send_async(TEST_MESSAGE)
@@ -64,7 +62,6 @@ class TestProtonQueueAdaptor(unittest.TestCase):
 
         self.assert_proton_called_correctly()
 
-    @utilities.test_utilities.async_test
     async def test_send_async_with_properties_success(self):
         """Test happy path of send_async."""
         awaitable = self.service.send_async(TEST_MESSAGE, properties=TEST_PROPERTIES)
@@ -88,7 +85,7 @@ class TestProtonQueueAdaptor(unittest.TestCase):
 
 
 @unittest.mock.patch('utilities.message_utilities.get_uuid', new=lambda: TEST_UUID)
-class TestProtonQueueAdaptorRetries(unittest.TestCase):
+class TestProtonQueueAdaptorRetries(unittest.IsolatedAsyncioTestCase):
     """Class to contain tests for the ProtonQueueAdaptor retry functionality."""
 
     def setUp(self) -> None:
@@ -106,7 +103,6 @@ class TestProtonQueueAdaptorRetries(unittest.TestCase):
 
     # TESTING SEND ASYNC METHOD
 
-    @utilities.test_utilities.async_test
     async def test_send_async_when_first_url_succeeds(self):
         """Test happy path of send_async."""
         awaitable = self.service.send_async(TEST_MESSAGE)
@@ -121,7 +117,6 @@ class TestProtonQueueAdaptorRetries(unittest.TestCase):
 
         self.assert_proton_called_correctly(TEST_QUEUE_MULTIPLE_URLS[0], call_index=0, call_count=1)
 
-    @utilities.test_utilities.async_test
     async def test_send_async_when_first_url_fails(self):
         """Test happy path of send_async."""
         awaitable = self.service.send_async(TEST_MESSAGE)
@@ -137,7 +132,6 @@ class TestProtonQueueAdaptorRetries(unittest.TestCase):
         self.assert_proton_called_correctly(TEST_QUEUE_MULTIPLE_URLS[0], call_index=0, call_count=2)
         self.assert_proton_called_correctly(TEST_QUEUE_MULTIPLE_URLS[1], call_index=1, call_count=2)
 
-    @utilities.test_utilities.async_test
     async def test_send_async_when_second_both_urls_fail_once(self):
         """Test happy path of send_async."""
         awaitable = self.service.send_async(TEST_MESSAGE)
@@ -156,7 +150,6 @@ class TestProtonQueueAdaptorRetries(unittest.TestCase):
         self.assert_proton_called_correctly(TEST_QUEUE_MULTIPLE_URLS[1], call_index=1, call_count=len(side_effects))
         self.assert_proton_called_correctly(TEST_QUEUE_MULTIPLE_URLS[0], call_index=2, call_count=len(side_effects))
 
-    @utilities.test_utilities.async_test
     async def test_send_async_when_second_both_urls_fail_twice(self):
         """Test happy path of send_async."""
         awaitable = self.service.send_async(TEST_MESSAGE)

--- a/common/retry/tests/test_retriable_action.py
+++ b/common/retry/tests/test_retriable_action.py
@@ -9,11 +9,10 @@ DEFAULT_RETRIES = 3
 DEFAULT_DELAY = 0.1
 
 
-class TestRetriableAction(unittest.TestCase):
+class TestRetriableAction(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         self.mock_action = mock.Mock()
 
-    @test_utilities.async_test
     async def test_should_only_try_once_if_action_succeeds(self):
         expected_result = "Result"
         self.mock_action.return_value = test_utilities.awaitable(expected_result)
@@ -26,7 +25,6 @@ class TestRetriableAction(unittest.TestCase):
         self.assertIsNone(result.exception, "No exception should be reported.")
         self.assertEqual(1, self.mock_action.call_count, "The action should only be executed once.")
 
-    @test_utilities.async_test
     async def test_should_retry_if_action_fails(self):
         expected_result = "Result"
         self.mock_action.side_effect = [Exception, test_utilities.awaitable(expected_result)]
@@ -40,7 +38,6 @@ class TestRetriableAction(unittest.TestCase):
         self.assertIsNone(result.exception, "No exception should be reported.")
         self.assertEqual(2, self.mock_action.call_count, "The action should be executed twice.")
 
-    @test_utilities.async_test
     async def test_should_retry_up_to_maximum_if_action_keeps_failing(self):
         exception_raised = Exception()
         self.mock_action.side_effect = exception_raised
@@ -55,7 +52,6 @@ class TestRetriableAction(unittest.TestCase):
         self.assertEqual(1 + DEFAULT_RETRIES, self.mock_action.call_count,
                          f"The action should be executed once and then retried {DEFAULT_RETRIES} times.")
 
-    @test_utilities.async_test
     async def test_should_try_once_if_retries_set_to_zero(self):
         self.mock_action.side_effect = Exception
 
@@ -64,7 +60,6 @@ class TestRetriableAction(unittest.TestCase):
         self.assertEqual(1, self.mock_action.call_count,
                          "The action should be tried once if zero retries are requested.")
 
-    @test_utilities.async_test
     async def test_should_try_twice_if_retries_set_to_one(self):
         self.mock_action.side_effect = Exception
 
@@ -73,7 +68,6 @@ class TestRetriableAction(unittest.TestCase):
         self.assertEqual(2, self.mock_action.call_count,
                          "The action should be tried twice if one retry is requested.")
 
-    @test_utilities.async_test
     async def test_should_report_success_if_custom_success_check_passes(self):
         action = retriable_action.RetriableAction(self.mock_action, retries=DEFAULT_RETRIES, delay=DEFAULT_DELAY) \
             .with_success_check(lambda r: r == "success")
@@ -85,7 +79,6 @@ class TestRetriableAction(unittest.TestCase):
         self.assertTrue(result.is_successful, "The action should be reported as successful.")
         self.assertEqual(1, self.mock_action.call_count, "The action should only be executed once.")
 
-    @test_utilities.async_test
     async def test_should_report_failure_if_custom_success_check_fails(self):
         action = retriable_action.RetriableAction(self.mock_action, retries=DEFAULT_RETRIES, delay=DEFAULT_DELAY) \
             .with_success_check(lambda r: r == "success")
@@ -98,7 +91,6 @@ class TestRetriableAction(unittest.TestCase):
         self.assertEqual(1 + DEFAULT_RETRIES, self.mock_action.call_count,
                          f"The action should be executed once and then retried {DEFAULT_RETRIES} times.")
 
-    @test_utilities.async_test
     async def test_should_not_retry_if_non_retriable_exception_raised(self):
         exception_raised = ValueError()
         self.mock_action.side_effect = exception_raised
@@ -115,7 +107,6 @@ class TestRetriableAction(unittest.TestCase):
                          "The action should not be retried if a non-retriable exception is raised")
 
     @mock.patch("asyncio.sleep")
-    @test_utilities.async_test
     async def test_should_only_sleep_between_retries(self, mock_sleep):
         self.mock_action.side_effect = Exception
         mock_sleep.return_value = test_utilities.awaitable(None)
@@ -128,7 +119,6 @@ class TestRetriableAction(unittest.TestCase):
                          f"{DEFAULT_RETRIES} times")
 
     @mock.patch("asyncio.sleep")
-    @test_utilities.async_test
     async def test_should_not_sleep_if_no_retries(self, mock_sleep):
         self.mock_action.side_effect = Exception
         mock_sleep.return_value = test_utilities.awaitable(None)

--- a/common/utilities/test_utilities.py
+++ b/common/utilities/test_utilities.py
@@ -1,24 +1,4 @@
 import asyncio
-import functools
-
-
-def async_test(f):
-    """
-    A wrapper for asynchronous tests.
-    By default unittest will not wait for asynchronous tests to complete even if the async functions are awaited.
-    By annotating a test method with `@async_test` it will cause the test to wait for asynchronous activities
-    to complete
-    :param f:
-    :return:
-    """
-    functools.wraps(f)
-
-    def wrapper(*args, **kwargs):
-        coro = asyncio.coroutine(f)
-        future = coro(*args, **kwargs)
-        asyncio.run(future)
-
-    return wrapper
 
 
 def awaitable(result=None):

--- a/common/utilities/tests/test_timing.py
+++ b/common/utilities/tests/test_timing.py
@@ -1,16 +1,15 @@
 import datetime
-from unittest import TestCase
+from unittest import IsolatedAsyncioTestCase
 from unittest.mock import patch, Mock
 
 from tornado.testing import AsyncHTTPTestCase
 from tornado.web import Application, RequestHandler
 from utilities import timing
-from utilities.test_utilities import async_test
 
 DEFAULT_RETURN = "default"
 
 
-class TestTimeUtilities(TestCase):
+class TestTimeUtilities(IsolatedAsyncioTestCase):
 
     @patch('time.perf_counter')
     def test_stopwatch(self, time_mock):
@@ -35,7 +34,6 @@ class TestTimeUtilities(TestCase):
 
     @patch('utilities.timing._log_time')
     @patch('utilities.timing.Stopwatch.stop_timer')
-    @async_test
     async def test_invoke_with_time(self, time_mock, log_mock):
         time_mock.return_value = 5
         with self.subTest("Sync version"):
@@ -50,7 +48,6 @@ class TestTimeUtilities(TestCase):
 
     @patch('utilities.timing.Stopwatch.stop_timer')
     @patch('utilities.timing._log_time')
-    @async_test
     async def test_exception_thrown_whilst_timing(self, log_mock, time_mock):
         time_mock.return_value = 10
         with self.subTest("Sync"):
@@ -66,7 +63,6 @@ class TestTimeUtilities(TestCase):
 
     @patch('utilities.timing.Stopwatch.stop_timer')
     @patch.object(timing, 'logger')
-    @async_test
     async def test_invoke_with_time_parameters(self, log_mock, time_mock):
         with self.subTest("Sync"):
             time_mock.return_value = 5
@@ -83,7 +79,6 @@ class TestTimeUtilities(TestCase):
 
     @patch('utilities.timing.Stopwatch.stop_timer')
     @patch.object(timing, 'logger')
-    @async_test
     async def test_async_times_execution_correctly(self, log_mock, time_mock):
         time_mock.return_value = 0
         task = self.default_method_async()
@@ -98,7 +93,6 @@ class TestTimeUtilities(TestCase):
 
     @patch('utilities.timing.Stopwatch.stop_timer')
     @patch.object(timing, 'logger')
-    @async_test
     async def test_invoke_with_time_varargs(self, log_mock, time_mock):
         with self.subTest("Sync"):
             time_mock.return_value = 5

--- a/examples/SCRWebService/message_handling/tests/test_message_forwarder.py
+++ b/examples/SCRWebService/message_handling/tests/test_message_forwarder.py
@@ -3,13 +3,12 @@ import unittest
 from unittest import mock
 from message_handling import message_forwarder as mh
 from builder.pystache_message_builder import MessageGenerationError
-from utilities.test_utilities import async_test, awaitable
+from utilities.test_utilities import awaitable
 
 
-class TestMessageForwarder(unittest.TestCase):
+class TestMessageForwarder(unittest.IsolatedAsyncioTestCase):
     """Tests associated with the MessageForwarder class"""
 
-    @async_test
     async def test_forwarding_message_attempts_to_populate_message_template(self):
         template_mock = mock.MagicMock()
         sender_mock = mock.MagicMock()
@@ -21,7 +20,6 @@ class TestMessageForwarder(unittest.TestCase):
         await handler.forward_message_to_mhs('interaction', input_json, None, None)
         template_mock.populate_template.assert_called_with(input_json)
 
-    @async_test
     async def test_exceptions_raised_during_message_population_are_caught_and_raised_as_MessageGenerationError(self):
         template_mock = mock.MagicMock()
         sender_mock = mock.MagicMock()
@@ -35,7 +33,6 @@ class TestMessageForwarder(unittest.TestCase):
             await handler.forward_message_to_mhs('interaction', input_json, None, None)
             self.assertEqual(str(e), 'Exception')
 
-    @async_test
     async def test_exception_raised_if_no_message_template_populator_found(self):
         sender_mock = mock.MagicMock()
         handler = mh.MessageForwarder({}, sender_mock)

--- a/integration-tests/integration_tests/integration_tests/component_tests/component_persistence_adaptor_tests.py
+++ b/integration-tests/integration_tests/integration_tests/component_tests/component_persistence_adaptor_tests.py
@@ -5,7 +5,6 @@ import uuid
 from exceptions import MaxRetriesExceeded
 from persistence.persistence_adaptor import PersistenceAdaptor, DuplicatePrimaryKeyError
 from persistence.persistence_adaptor_factory import get_persistence_adaptor, PERSISTENCE_ADAPTOR_TYPES
-from utilities import test_utilities
 
 MONGODB_ENDPOINT_URL = 'mongodb://mongodb:27017'
 DYNAMODB_ENDPOINT_URL = 'http://dynamodb:8000'
@@ -33,16 +32,14 @@ DB_KEY_FIELDS = {
 }
 
 
-class DbAdaptorsTests(unittest.TestCase):
+class DbAdaptorsTests(unittest.IsolatedAsyncioTestCase):
 
     keys = []
 
-    @test_utilities.async_test
-    async def setUp(self) -> None:
+    async def asyncSetUp(self) -> None:
         await self.clean_up()
 
-    @test_utilities.async_test
-    async def tearDown(self) -> None:
+    async def asyncTearDown(self) -> None:
         await self.clean_up()
 
     async def clean_up(self):
@@ -52,7 +49,6 @@ class DbAdaptorsTests(unittest.TestCase):
                 await adaptor.delete(key)
         self.keys = []
 
-    @test_utilities.async_test
     async def test_can_CRUD(self):
         for adaptor_type in PERSISTENCE_ADAPTOR_TYPES:
             with self.subTest(f"{adaptor_type}"):
@@ -93,7 +89,6 @@ class DbAdaptorsTests(unittest.TestCase):
                 value = await adaptor.get(other_key)
                 self.assertIsNone(value)
 
-    @test_utilities.async_test
     async def test_error_if_same_key_inserted_twice(self):
         for adaptor_type in PERSISTENCE_ADAPTOR_TYPES:
             with self.subTest(f"{adaptor_type}"):
@@ -112,11 +107,9 @@ class DbAdaptorsTests(unittest.TestCase):
                 else:
                     self.fail(f"Expected '{type(DuplicatePrimaryKeyError)}' exception not raised")
 
-    @test_utilities.async_test
     async def test_error_if_data_to_add_has_primary_key_in(self):
         await self._test_error_if_data_has_primary_key_in(PersistenceAdaptor.add.__name__)
 
-    @test_utilities.async_test
     async def test_error_if_data_to_update_has_primary_key_in(self):
         await self._test_error_if_data_has_primary_key_in(PersistenceAdaptor.update.__name__)
 

--- a/mhs/common/mhs_common/routing/tests/test_sds_api_client.py
+++ b/mhs/common/mhs_common/routing/tests/test_sds_api_client.py
@@ -43,9 +43,9 @@ EXPECTED_RELIABILITY = json.loads(load_test_data('reliability.json'))
 CORRELATION_ID = 'CORRELATION_ID'
 
 
-class TestSdsApiClient(unittest.TestCase):
+class TestSdsApiClient(unittest.IsolatedAsyncioTestCase):
 
-    def setUp(self) -> None:
+    async def asyncSetUp(self) -> None:
         # Mock the httpclient.AsyncHTTPClient() constructor
         patcher = unittest.mock.patch.object(httpclient, "AsyncHTTPClient")
         mock_http_client_constructor = patcher.start()
@@ -60,7 +60,6 @@ class TestSdsApiClient(unittest.TestCase):
     def tearDown(self) -> None:
         mdc.correlation_id.set(None)
 
-    @test_utilities.async_test
     async def test_should_retrieve_routing_and_reliability_details_if_given_org_code(self):
         self.routing = sds_api_client.SdsApiClient(BASE_URL, API_KEY, SPINE_ORG_CODE)
         for function_to_test, expected_result in [(self.routing.get_end_point, EXPECTED_ROUTING), (self.routing.get_reliability, EXPECTED_RELIABILITY)]:
@@ -77,7 +76,6 @@ class TestSdsApiClient(unittest.TestCase):
                 self._assert_http_client_called_with_expected_args([expected_device_url, expected_endpoint_url])
 
 
-    @test_utilities.async_test
     async def test_should_retrieve_routing_and_reliability_details_if_given_no_org_code(self):
         self.routing = sds_api_client.SdsApiClient(BASE_URL, API_KEY, SPINE_ORG_CODE)
         for function_to_test, expected_result in [(self.routing.get_end_point, EXPECTED_ROUTING), (self.routing.get_reliability, EXPECTED_RELIABILITY)]:
@@ -93,7 +91,6 @@ class TestSdsApiClient(unittest.TestCase):
 
                 self._assert_http_client_called_with_expected_args([expected_device_url, expected_endpoint_url])
 
-    @test_utilities.async_test
     async def test_should_retrieve_routing_and_reliability_first_endpoint_details_if_there_are_multiple_results(self):
         self.routing = sds_api_client.SdsApiClient(BASE_URL, API_KEY, SPINE_ORG_CODE)
         for function_to_test, expected_result in [(self.routing.get_end_point, EXPECTED_ROUTING), (self.routing.get_reliability, EXPECTED_RELIABILITY)]:
@@ -109,7 +106,6 @@ class TestSdsApiClient(unittest.TestCase):
 
                 self._assert_http_client_called_with_expected_args([expected_device_url, expected_endpoint_url])
 
-    @test_utilities.async_test
     async def test_should_raise_error_if_endpoint_yields_no_result(self):
         self.routing = sds_api_client.SdsApiClient(BASE_URL, API_KEY, SPINE_ORG_CODE)
         self._given_http_client_returns_a_json_response(SDS_JSON_ZERO_RESULTS_RESPONSE, SDS_JSON_ZERO_RESULTS_RESPONSE)
@@ -119,7 +115,6 @@ class TestSdsApiClient(unittest.TestCase):
                 with self.assertRaises(SDSException):
                     await function_to_test(SERVICE_ID, ORG_CODE)
 
-    @test_utilities.async_test
     async def test_should_raise_error_if_endpoint_returns_unexpected_response(self):
         self.routing = sds_api_client.SdsApiClient(BASE_URL, API_KEY, SPINE_ORG_CODE)
         self._given_http_client_returns_a_json_response(SDS_JSON_UNEXPECTED_RESPONSE, SDS_JSON_UNEXPECTED_RESPONSE)

--- a/mhs/common/mhs_common/routing/tests/test_spine_route_lookup_client.py
+++ b/mhs/common/mhs_common/routing/tests/test_spine_route_lookup_client.py
@@ -23,7 +23,7 @@ JSON_RESPONSE = '{"one": 1, "two": "2"}'
 EXPECTED_RESPONSE = {"one": 1, "two": "2"}
 
 
-class TestSpineRouteLookupClient(unittest.TestCase):
+class TestSpineRouteLookupClient(unittest.IsolatedAsyncioTestCase):
 
     def setUp(self) -> None:
         # Mock the httpclient.AsyncHTTPClient() constructor
@@ -35,7 +35,6 @@ class TestSpineRouteLookupClient(unittest.TestCase):
         self.mock_http_client = unittest.mock.MagicMock()
         mock_http_client_constructor.return_value = self.mock_http_client
 
-    @test_utilities.async_test
     async def test_should_retrieve_endpoint_details_if_given_org_code(self):
         self.routing = spine_route_lookup_client.SpineRouteLookupClient(BASE_URL, SPINE_ORG_CODE)
         self._given_http_client_returns_a_json_response()
@@ -46,7 +45,6 @@ class TestSpineRouteLookupClient(unittest.TestCase):
         expected_url = self._build_url(path=ROUTING_PATH)
         self._assert_http_client_called_with_expected_args(expected_url, ca_certs=ANY)
 
-    @test_utilities.async_test
     async def test_should_retrieve_endpoint_details_with_default_org_code(self):
         self.routing = spine_route_lookup_client.SpineRouteLookupClient(BASE_URL, SPINE_ORG_CODE)
         self._given_http_client_returns_a_json_response()
@@ -57,7 +55,6 @@ class TestSpineRouteLookupClient(unittest.TestCase):
         expected_url = self._build_url(path=ROUTING_PATH, org_code=SPINE_ORG_CODE)
         self._assert_http_client_called_with_expected_args(expected_url, ca_certs=ANY)
 
-    @test_utilities.async_test
     async def test_should_pass_through_exception_if_raised_when_retrieving_endpoint_details(self):
         self.routing = spine_route_lookup_client.SpineRouteLookupClient(BASE_URL, SPINE_ORG_CODE)
         self.mock_http_client.fetch.side_effect = IOError("Something went wrong!")
@@ -65,7 +62,6 @@ class TestSpineRouteLookupClient(unittest.TestCase):
         with self.assertRaises(IOError):
             await self.routing.get_end_point(SERVICE_ID, ORG_CODE)
 
-    @test_utilities.async_test
     async def test_should_use_certificate_details_if_provided_when_retrieving_endpoint_details(self):
         self.routing = spine_route_lookup_client.SpineRouteLookupClient(BASE_URL, SPINE_ORG_CODE,
                                                                   client_cert=CLIENT_CERT_PATH,
@@ -78,7 +74,6 @@ class TestSpineRouteLookupClient(unittest.TestCase):
         self._assert_http_client_called_with_expected_args(expected_url, client_cert=CLIENT_CERT_PATH,
                                                            client_key=CLIENT_KEY_PATH, ca_certs=CA_CERTS_PATH)
 
-    @test_utilities.async_test
     async def test_should_use_proxy_if_provided_when_retrieving_endpoint_details(self):
         self.routing = spine_route_lookup_client.SpineRouteLookupClient(BASE_URL, SPINE_ORG_CODE,
                                                                   http_proxy_host=HTTP_PROXY_HOST,
@@ -91,7 +86,6 @@ class TestSpineRouteLookupClient(unittest.TestCase):
         self._assert_http_client_called_with_expected_args(expected_url, proxy_host=HTTP_PROXY_HOST,
                                                            proxy_port=HTTP_PROXY_PORT, ca_certs=ANY)
 
-    @test_utilities.async_test
     async def test_should_retrieve_reliability_details_if_given_org_code(self):
         self.routing = spine_route_lookup_client.SpineRouteLookupClient(BASE_URL, SPINE_ORG_CODE)
         self._given_http_client_returns_a_json_response()
@@ -102,7 +96,6 @@ class TestSpineRouteLookupClient(unittest.TestCase):
         expected_url = self._build_url(path=RELIABILITY_PATH)
         self._assert_http_client_called_with_expected_args(expected_url, ca_certs=ANY)
 
-    @test_utilities.async_test
     async def test_should_retrieve_reliability_details_with_default_org_code(self):
         self.routing = spine_route_lookup_client.SpineRouteLookupClient(BASE_URL, SPINE_ORG_CODE)
         self._given_http_client_returns_a_json_response()
@@ -113,7 +106,6 @@ class TestSpineRouteLookupClient(unittest.TestCase):
         expected_url = self._build_url(path=RELIABILITY_PATH, org_code=SPINE_ORG_CODE)
         self._assert_http_client_called_with_expected_args(expected_url, ca_certs=ANY)
 
-    @test_utilities.async_test
     async def test_should_pass_through_exception_if_raised_when_retrieving_reliability_details(self):
         self.routing = spine_route_lookup_client.SpineRouteLookupClient(BASE_URL, SPINE_ORG_CODE)
         self.mock_http_client.fetch.side_effect = IOError("Something went wrong!")
@@ -121,7 +113,6 @@ class TestSpineRouteLookupClient(unittest.TestCase):
         with self.assertRaises(IOError):
             await self.routing.get_reliability(SERVICE_ID, ORG_CODE)
 
-    @test_utilities.async_test
     async def test_should_use_certificate_details_if_provided_when_retrieving_reliability_details(self):
         self.routing = spine_route_lookup_client.SpineRouteLookupClient(BASE_URL, SPINE_ORG_CODE,
                                                                   client_cert=CLIENT_CERT_PATH,
@@ -134,7 +125,6 @@ class TestSpineRouteLookupClient(unittest.TestCase):
         self._assert_http_client_called_with_expected_args(expected_url, client_cert=CLIENT_CERT_PATH,
                                                            client_key=CLIENT_KEY_PATH, ca_certs=CA_CERTS_PATH)
 
-    @test_utilities.async_test
     async def test_should_use_proxy_if_provided_when_retrieving_reliability_details(self):
         self.routing = spine_route_lookup_client.SpineRouteLookupClient(BASE_URL, SPINE_ORG_CODE,
                                                                   http_proxy_host=HTTP_PROXY_HOST,

--- a/mhs/common/mhs_common/workflow/tests/test_asynchronous_express.py
+++ b/mhs/common/mhs_common/workflow/tests/test_asynchronous_express.py
@@ -17,7 +17,6 @@ from mhs_common.state import work_description
 from mhs_common.state.work_description import MessageStatus
 from mhs_common.workflow.common import MessageData
 from utilities import test_utilities
-from utilities.test_utilities import async_test
 
 FROM_PARTY_KEY = 'from-party-key'
 TO_PARTY_KEY = 'to-party-key'
@@ -64,7 +63,7 @@ MHS_RETRY_VAL = 3
 TEST_MESSAGE_DIR = "mhs_common/messages/tests/test_messages"
 
 
-class TestAsynchronousExpressWorkflow(unittest.TestCase):
+class TestAsynchronousExpressWorkflow(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         self.mock_persistence_store = mock.MagicMock()
         self.mock_transmission_adaptor = mock.MagicMock()
@@ -100,7 +99,6 @@ class TestAsynchronousExpressWorkflow(unittest.TestCase):
     ############################
 
     @mock.patch('utilities.integration_adaptors_logger.IntegrationAdaptorsLogger.audit')
-    @async_test
     async def test_successful_handle_outbound_message(self, audit_log_mock):
         response = mock.MagicMock()
         response.code = 202
@@ -145,7 +143,6 @@ class TestAsynchronousExpressWorkflow(unittest.TestCase):
                                           })
 
     @mock.patch('mhs_common.state.work_description.create_new_work_description')
-    @async_test
     async def test_handle_outbound_doesnt_overwrite_work_description(self, wdo_mock):
         response = mock.MagicMock()
         response.code = 202
@@ -177,7 +174,6 @@ class TestAsynchronousExpressWorkflow(unittest.TestCase):
         wdo_mock.assert_not_called()
         self.assertEqual(wdo.workflow, 'This should not change')
 
-    @async_test
     async def test_handle_outbound_message_serialisation_fails(self):
         self.setup_mock_work_description()
         self._setup_routing_mock()
@@ -195,7 +191,6 @@ class TestAsynchronousExpressWorkflow(unittest.TestCase):
                          self.mock_work_description.set_outbound_status.call_args_list)
         self.mock_transmission_adaptor.make_request.assert_not_called()
 
-    @async_test
     async def test_handle_outbound_message_fails_with_serialised_message_too_large(self):
         self.setup_mock_work_description()
         self._setup_routing_mock()
@@ -213,7 +208,6 @@ class TestAsynchronousExpressWorkflow(unittest.TestCase):
                          self.mock_work_description.set_outbound_status.call_args_list)
         self.mock_transmission_adaptor.make_request.assert_not_called()
 
-    @async_test
     async def test_handle_outbound_message_error_when_looking_up_spine_url(self):
         self.setup_mock_work_description()
         self.mock_routing_reliability.get_end_point.side_effect = Exception()
@@ -229,7 +223,6 @@ class TestAsynchronousExpressWorkflow(unittest.TestCase):
                          self.mock_work_description.set_outbound_status.call_args_list)
         self.mock_transmission_adaptor.make_request.assert_not_called()
 
-    @async_test
     async def test_non_http_error_handled_when_making_request_to_spine(self):
         self.setup_mock_work_description()
         self._setup_routing_mock()
@@ -252,7 +245,6 @@ class TestAsynchronousExpressWorkflow(unittest.TestCase):
             self.mock_work_description.set_outbound_status.call_args_list)
 
     @mock.patch('utilities.integration_adaptors_logger.IntegrationAdaptorsLogger.audit')
-    @async_test
     async def test_well_formed_soap_error_response_from_spine(self, audit_log_mock):
         self.setup_mock_work_description()
         self._setup_routing_mock()
@@ -293,7 +285,6 @@ class TestAsynchronousExpressWorkflow(unittest.TestCase):
                                           fparams={'WorkflowName': 'async-express'})
 
     @mock.patch('utilities.integration_adaptors_logger.IntegrationAdaptorsLogger.audit')
-    @async_test
     async def test_unhandled_response_from_spine(self, audit_log_mock):
         self.setup_mock_work_description()
         self._setup_routing_mock()
@@ -322,7 +313,6 @@ class TestAsynchronousExpressWorkflow(unittest.TestCase):
                                           fparams={'WorkflowName': 'async-express'})
 
     @mock.patch('utilities.integration_adaptors_logger.IntegrationAdaptorsLogger.audit')
-    @async_test
     async def test_well_formed_ebxml_error_response_from_spine(self, audit_log_mock):
         self.setup_mock_work_description()
         self._setup_routing_mock()
@@ -381,7 +371,6 @@ class TestAsynchronousExpressWorkflow(unittest.TestCase):
     ############################
 
     @mock.patch('utilities.integration_adaptors_logger.IntegrationAdaptorsLogger.audit')
-    @async_test
     async def test_successful_handle_inbound_message(self, audit_log_mock):
         self.setup_mock_work_description()
         self.mock_queue_adaptor.send_async.return_value = test_utilities.awaitable(None)
@@ -397,7 +386,6 @@ class TestAsynchronousExpressWorkflow(unittest.TestCase):
             '{WorkflowName} inbound workflow completed. Message placed on queue, returning {Acknowledgement} to spine',
             fparams={'Acknowledgement': 'INBOUND_RESPONSE_SUCCESSFULLY_PROCESSED', 'WorkflowName': 'async-express'})
 
-    @async_test
     async def test_handle_inbound_message_error_putting_message_onto_queue_despite_retries(self):
         self.setup_mock_work_description()
         future = asyncio.Future()

--- a/mhs/common/mhs_common/workflow/tests/test_common.py
+++ b/mhs/common/mhs_common/workflow/tests/test_common.py
@@ -6,7 +6,6 @@ from unittest import mock
 from mhs_common.request import request_body_schema
 from mhs_common.workflow.common import MessageData
 from utilities import test_utilities
-from utilities.test_utilities import async_test
 
 import mhs_common.state.work_description as wd
 from mhs_common.workflow import common
@@ -54,13 +53,12 @@ class DummyCommonWorkflow(common.CommonWorkflow):
 
 
 
-class TestCommonWorkflow(unittest.TestCase):
+class TestCommonWorkflow(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         self.mock_routing_reliability = mock.MagicMock()
 
         self.workflow = DummyCommonWorkflow(self.mock_routing_reliability)
 
-    @async_test
     async def test_lookup_endpoint_details(self):
         self.mock_routing_reliability.get_end_point.return_value = test_utilities.awaitable({
             MHS_END_POINT_KEY: [MHS_END_POINT_VALUE],
@@ -77,7 +75,6 @@ class TestCommonWorkflow(unittest.TestCase):
         self.assertEqual(details['cpa_id'], MHS_CPA_ID_VALUE)
         self.assertEqual(details['to_asid'], MHS_ASID_VALUE)
 
-    @async_test
     async def test_lookup_endpoint_details_handles_no_ods_code_passed(self):
         self.mock_routing_reliability.get_end_point.return_value = test_utilities.awaitable({
             MHS_END_POINT_KEY: [MHS_END_POINT_VALUE],
@@ -97,21 +94,18 @@ class TestCommonWorkflow(unittest.TestCase):
         self.assertEqual(details['cpa_id'], MHS_CPA_ID_VALUE)
         self.assertEqual(details['to_asid'], MHS_ASID_VALUE)
 
-    @async_test
     async def test_lookup_endpoint_details_error(self):
         self.mock_routing_reliability.get_end_point.side_effect = Exception()
 
         with self.assertRaises(Exception):
             await self.workflow._lookup_endpoint_details(INTERACTION_DETAILS)
 
-    @async_test
     async def test_extract_endpoint_url_no_endpoints_returned(self):
         endpoint_details = {MHS_END_POINT_KEY: []}
 
         with self.assertRaises(IndexError):
             common.CommonWorkflow._extract_endpoint_url(endpoint_details)
 
-    @async_test
     async def test_extract_endpoint_url_multiple_endpoints_returned(self):
         expected_url = "first_url"
         endpoint_details = {MHS_END_POINT_KEY: [expected_url, "second-url"]}
@@ -120,14 +114,12 @@ class TestCommonWorkflow(unittest.TestCase):
 
         self.assertEqual(expected_url, actual_url)
 
-    @async_test
     async def test_extract_no_to_asid_returned(self):
         endpoint_details = {MHS_TO_ASID: []}
 
         with self.assertRaises(IndexError):
             common.CommonWorkflow._extract_asid(endpoint_details)
 
-    @async_test
     async def test_extract_asid_multiple_returned(self):
         expected_asid = "asid 1"
         endpoint_details = {MHS_TO_ASID: [expected_asid, "asid 2"]}

--- a/mhs/common/mhs_common/workflow/tests/test_common_asynchronous.py
+++ b/mhs/common/mhs_common/workflow/tests/test_common_asynchronous.py
@@ -7,7 +7,6 @@ from mhs_common.request import request_body_schema
 from mhs_common.workflow import common_asynchronous
 from mhs_common.workflow.common import MessageData
 from utilities import test_utilities
-from utilities.test_utilities import async_test
 
 SERVICE = 'service'
 ACTION = 'action'
@@ -44,7 +43,7 @@ class DummyCommonAsynchronousWorkflow(common_asynchronous.CommonAsynchronousWork
         pass
 
 
-class TestCommonAsynchronousWorkflow(unittest.TestCase):
+class TestCommonAsynchronousWorkflow(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         party_key = 'PARTY_KEY'
         persistence_store = mock.MagicMock()
@@ -60,7 +59,6 @@ class TestCommonAsynchronousWorkflow(unittest.TestCase):
                                                         max_request_size,
                                                         self.mock_routing_reliability)
 
-    @async_test
     async def test_lookup_reliability_details(self):
         self.mock_routing_reliability.get_reliability.return_value = test_utilities.awaitable(
             EXPECTED_RELIABILITY_DETAILS)
@@ -70,7 +68,6 @@ class TestCommonAsynchronousWorkflow(unittest.TestCase):
         self.mock_routing_reliability.get_reliability.assert_called_with(SERVICE_ID, ODS_CODE)
         self.assertEqual(reliability_details, EXPECTED_RELIABILITY_DETAILS)
 
-    @async_test
     async def test_lookup_reliability_details_error(self):
         self.mock_routing_reliability.get_reliability.side_effect = Exception()
 

--- a/mhs/common/mhs_common/workflow/tests/test_sync_async.py
+++ b/mhs/common/mhs_common/workflow/tests/test_sync_async.py
@@ -1,4 +1,4 @@
-from unittest import TestCase
+from unittest import IsolatedAsyncioTestCase
 from unittest.mock import patch, MagicMock
 
 from mhs_common import workflow
@@ -9,7 +9,7 @@ from mhs_common.workflow.common import MessageData
 from utilities import test_utilities
 
 
-class TestSyncAsyncWorkflowOutbound(TestCase):
+class TestSyncAsyncWorkflowOutbound(IsolatedAsyncioTestCase):
 
     def setUp(self):
         self.persistence = MagicMock()
@@ -20,7 +20,6 @@ class TestSyncAsyncWorkflowOutbound(TestCase):
                                                      resynchroniser=self.resync)
 
     @patch('mhs_common.state.work_description.create_new_work_description')
-    @test_utilities.async_test
     async def test_sync_async_happy_path(self, wd_mock):
         wdo = MagicMock()
         wdo.publish.return_value = test_utilities.awaitable(None)
@@ -51,7 +50,6 @@ class TestSyncAsyncWorkflowOutbound(TestCase):
         self.assertEqual(actual_wdo, wdo)
 
     @patch('mhs_common.state.work_description.create_new_work_description')
-    @test_utilities.async_test
     async def test_async_workflow_return_error_code(self, wd_mock):
         wdo = MagicMock()
         wdo.publish.return_value = test_utilities.awaitable(None)
@@ -69,7 +67,6 @@ class TestSyncAsyncWorkflowOutbound(TestCase):
         self.assertEqual("Failed to reach spine", response)
 
     @patch('mhs_common.state.work_description.create_new_work_description')
-    @test_utilities.async_test
     async def test_resync_failure(self, wd_mock):
         async def resync_raises_exception(fake_key):
             raise resynchroniser.SyncAsyncResponseException()
@@ -92,7 +89,6 @@ class TestSyncAsyncWorkflowOutbound(TestCase):
         self.assertEqual(status, 500)
         self.assertEqual("No async response received from sync-async store", response)
 
-    @test_utilities.async_test
     async def test_success_response(self):
         wdo = MagicMock()
         wdo.update.return_value = test_utilities.awaitable(None)
@@ -103,7 +99,6 @@ class TestSyncAsyncWorkflowOutbound(TestCase):
         wdo.set_outbound_status.assert_called_once_with(
             wd.MessageStatus.OUTBOUND_SYNC_ASYNC_MESSAGE_SUCCESSFULLY_RESPONDED)
 
-    @test_utilities.async_test
     async def test_failure_response(self):
         wdo = MagicMock()
         wdo.update.return_value = test_utilities.awaitable(None)
@@ -114,7 +109,7 @@ class TestSyncAsyncWorkflowOutbound(TestCase):
         wdo.set_outbound_status.assert_called_once_with(wd.MessageStatus.OUTBOUND_SYNC_ASYNC_MESSAGE_FAILED_TO_RESPOND)
 
 
-class TestSyncAsyncWorkflowInbound(TestCase):
+class TestSyncAsyncWorkflowInbound(IsolatedAsyncioTestCase):
 
     message_data = MessageData(None, 'wqe', None, None)
 
@@ -124,7 +119,6 @@ class TestSyncAsyncWorkflowInbound(TestCase):
 
         self.workflow = sync_async.SyncAsyncWorkflow(sync_async_store=self.persistence)
 
-    @test_utilities.async_test
     async def test_inbound_workflow_happy_path(self):
         self.workflow.sync_async_store.add.return_value = test_utilities.awaitable(True)
         self.work_description.set_inbound_status.return_value = test_utilities.awaitable(True)

--- a/mhs/common/mhs_common/workflow/tests/test_sync_async_resynchroniser.py
+++ b/mhs/common/mhs_common/workflow/tests/test_sync_async_resynchroniser.py
@@ -1,4 +1,4 @@
-from unittest import TestCase
+from unittest import IsolatedAsyncioTestCase
 from unittest.mock import MagicMock, patch
 
 from utilities import test_utilities
@@ -8,9 +8,8 @@ from mhs_common.workflow import sync_async_resynchroniser as resync
 PARTY_ID = "PARTY-ID"
 
 
-class TestSyncAsyncReSynchroniser(TestCase):
+class TestSyncAsyncReSynchroniser(IsolatedAsyncioTestCase):
 
-    @test_utilities.async_test
     async def test_should_return_correct_result_on_resynchronisation(self):
         # Arrange
         store = MagicMock()
@@ -25,7 +24,6 @@ class TestSyncAsyncReSynchroniser(TestCase):
         self.assertTrue(result)
 
     @patch('asyncio.sleep')
-    @test_utilities.async_test
     async def test_should_return_correct_result_if_retry_succeeds(self, sleep_mock):
         # Arrange
         store = MagicMock()
@@ -41,7 +39,6 @@ class TestSyncAsyncReSynchroniser(TestCase):
         self.assertEqual(store.get.call_count, 2)
 
     @patch('asyncio.sleep')
-    @test_utilities.async_test
     async def test_should_respect_max_retries_while_attempting_to_retry(self, sleep_mock):
         # Arrange
         store = MagicMock()
@@ -59,7 +56,6 @@ class TestSyncAsyncReSynchroniser(TestCase):
                          f"Retrieving the message should be tried once and then retried {max_retries} times.")
 
     @patch('asyncio.sleep')
-    @test_utilities.async_test
     async def test_should_perform_correct_number_of_sleeps_between_retries(self, sleep_mock):
         # Arrange
         store = MagicMock()
@@ -76,7 +72,6 @@ class TestSyncAsyncReSynchroniser(TestCase):
         self.assertEqual(1 + max_retries, sleep_mock.call_count)
 
     @patch('asyncio.sleep')
-    @test_utilities.async_test
     async def test_should_initially_wait_before_polling_store(self, sleep_mock):
         # Arrange
         store = MagicMock()

--- a/mhs/common/mhs_common/workflow/tests/test_synchronous.py
+++ b/mhs/common/mhs_common/workflow/tests/test_synchronous.py
@@ -10,7 +10,6 @@ from mhs_common.workflow import synchronous as sync
 from mhs_common import workflow
 from mhs_common.state import work_description
 from utilities import test_utilities
-from utilities.test_utilities import async_test
 
 PARTY_KEY = "313"
 LOOKUP_RESPONSE = {
@@ -20,7 +19,7 @@ LOOKUP_RESPONSE = {
 MAX_REQUEST_SIZE = 5000000
 
 
-class TestSynchronousWorkflow(unittest.TestCase):
+class TestSynchronousWorkflow(unittest.IsolatedAsyncioTestCase):
 
     def setUp(self) -> None:
         self.wd_store = mock.MagicMock()
@@ -36,7 +35,6 @@ class TestSynchronousWorkflow(unittest.TestCase):
         )
 
     @mock.patch('mhs_common.state.work_description.create_new_work_description')
-    @async_test
     async def test_should_set_store_outbound_status_to_received_when_handling_outbound_message(self, wd_mock):
         wdo_mock = mock.MagicMock()
         wd_mock.return_value = wdo_mock
@@ -57,7 +55,6 @@ class TestSynchronousWorkflow(unittest.TestCase):
 
     @mock.patch.object(sync, 'logger')
     @mock.patch('mhs_common.state.work_description.create_new_work_description')
-    @async_test
     async def test_asid_lookup_failure_set_store(self, wd_mock, log_mock):
         wdo = mock.MagicMock()
         wdo.publish.return_value = test_utilities.awaitable(None)
@@ -79,7 +76,6 @@ class TestSynchronousWorkflow(unittest.TestCase):
 
     @mock.patch.object(sync, 'logger')
     @mock.patch('mhs_common.state.work_description.create_new_work_description')
-    @async_test
     async def test_prepare_message_failure(self, wd_mock, log_mock):
         wdo = mock.MagicMock()
         wdo.publish.return_value = test_utilities.awaitable(None)
@@ -104,7 +100,6 @@ class TestSynchronousWorkflow(unittest.TestCase):
 
     @mock.patch('mhs_common.messages.soap_envelope.SoapEnvelope')
     @mock.patch('mhs_common.state.work_description.create_new_work_description')
-    @async_test
     async def test_prepare_message_success_but_message_too_large(self, wd_mock, mock_soap_envelope):
         wdo = mock.MagicMock()
         wdo.publish.return_value = test_utilities.awaitable(None)
@@ -129,7 +124,6 @@ class TestSynchronousWorkflow(unittest.TestCase):
 
     @mock.patch.object(sync, 'logger')
     @mock.patch('mhs_common.state.work_description.create_new_work_description')
-    @async_test
     async def test_send_message_failure(self, wd_mock, log_mock):
         wdo = mock.MagicMock()
         wdo.publish.return_value = test_utilities.awaitable(None)
@@ -158,7 +152,6 @@ class TestSynchronousWorkflow(unittest.TestCase):
 
     @mock.patch.object(sync, 'logger')
     @mock.patch('mhs_common.state.work_description.create_new_work_description')
-    @async_test
     async def test_send_message_http_error(self, wd_mock, log_mock):
         wdo = mock.MagicMock()
         wdo.publish.return_value = test_utilities.awaitable(None)
@@ -185,7 +178,6 @@ class TestSynchronousWorkflow(unittest.TestCase):
         self.assertEqual(text, 'Error(s) received from Spine: HTTP 409: Conflict')
 
     @mock.patch('mhs_common.state.work_description.create_new_work_description')
-    @async_test
     async def test_send_message_http_status_code_err(self, wd_mock):
         self._setup_success_workflow()
         wdo = mock.MagicMock()
@@ -210,7 +202,6 @@ class TestSynchronousWorkflow(unittest.TestCase):
         self.assertEqual(text[:40], 'Error(s) received from Spine: HTTP 451: ')
 
     @mock.patch('mhs_common.state.work_description.create_new_work_description')
-    @async_test
     async def test_send_message_success_message(self, wd_mock):
         self._setup_success_workflow()
         wdo = mock.MagicMock()
@@ -232,7 +223,6 @@ class TestSynchronousWorkflow(unittest.TestCase):
 
     @mock.patch('mhs_common.workflow.synchronous.logger')
     @mock.patch('mhs_common.state.work_description.create_new_work_description')
-    @async_test
     async def test_success_audit_log_should_be_called_when_successful_response_is_returned_from_spine(self, wd_mock,
                                                                                                       log_mock):
         self._setup_success_workflow()
@@ -255,7 +245,6 @@ class TestSynchronousWorkflow(unittest.TestCase):
 
     @mock.patch('mhs_common.workflow.synchronous.logger')
     @mock.patch('mhs_common.state.work_description.create_new_work_description')
-    @async_test
     async def test_initial_audit_log_should_be_called_handling_is_invoked(self, wd_mock, log_mock):
         self._setup_success_workflow()
         wdo = mock.MagicMock()
@@ -279,7 +268,6 @@ class TestSynchronousWorkflow(unittest.TestCase):
         log_mock.audit('Outbound Synchronous workflow invoked.')
 
     @mock.patch('mhs_common.state.work_description.create_new_work_description')
-    @async_test
     async def test_handle_outbound_errors_when_no_asid_provided(self, wd_mock):
         wdo = mock.MagicMock()
         wdo.publish.return_value = test_utilities.awaitable(None)
@@ -296,12 +284,10 @@ class TestSynchronousWorkflow(unittest.TestCase):
         self.assertEqual(error, 400)
         self.assertEqual(text, '`from_asid` header field required for sync messages')
 
-    @async_test
     async def test_no_inbound(self):
         with self.assertRaises(NotImplementedError):
             await self.wf.handle_inbound_message("1", "2", mock.MagicMock(), "payload")
 
-    @async_test
     async def test_prepare_message(self):
         id, headers, message = await self.wf._prepare_outbound_message("message_id", "to_asid", "from_asid", RequestBody("message", [], []),
                                                                        {'service': 'service', 'action': 'action'})
@@ -312,7 +298,6 @@ class TestSynchronousWorkflow(unittest.TestCase):
                                    'type': 'text/xml'})
 
     @mock.patch('mhs_common.messages.soap_envelope.SoapEnvelope')
-    @async_test
     async def test_prepare_message_correct_constructor_call(self, envelope_patch):
         envelope = mock.MagicMock()
         envelope_patch.return_value = envelope
@@ -332,14 +317,12 @@ class TestSynchronousWorkflow(unittest.TestCase):
         envelope.serialize.assert_called_once()
 
     @mock.patch('mhs_common.messages.soap_envelope.SoapEnvelope.serialize')
-    @async_test
     async def test_prepare_message_raises_exception(self, serialize_mock):
         serialize_mock.side_effect = Exception()
         with self.assertRaises(Exception):
             await self.wf._prepare_outbound_message("message_id", "to_asid", "from_asid", "mesasge",
                                                     {'service': 'service', 'action': 'action'})
 
-    @async_test
     async def test_success_response(self):
         wdo = mock.MagicMock()
         wdo.publish.return_value = test_utilities.awaitable(None)
@@ -348,7 +331,6 @@ class TestSynchronousWorkflow(unittest.TestCase):
         await self.wf.set_successful_message_response(wdo)
         wdo.set_outbound_status.assert_called_once_with(work_description.MessageStatus.SYNC_RESPONSE_SUCCESSFUL)
 
-    @async_test
     async def test_failure_response(self):
         wdo = mock.MagicMock()
         wdo.publish.return_value = test_utilities.awaitable(None)

--- a/mhs/spineroutelookup/lookup/tests/test_mhs_attribute_lookup.py
+++ b/mhs/spineroutelookup/lookup/tests/test_mhs_attribute_lookup.py
@@ -1,8 +1,7 @@
-from unittest import TestCase
+from unittest import IsolatedAsyncioTestCase
 from unittest import mock
 
 from utilities import test_utilities
-from utilities.test_utilities import async_test
 
 import lookup.mhs_attribute_lookup as mhs_attribute_lookup
 import lookup.tests.ldap_mocks as mocks
@@ -39,12 +38,11 @@ expected_mhs_attributes = {
 }
 
 
-class TestMHSAttributeLookup(TestCase):
+class TestMHSAttributeLookup(IsolatedAsyncioTestCase):
 
     def setUp(self) -> None:
         self.cache = mock.MagicMock()
 
-    @async_test
     async def test_get_endpoint(self):
         self.cache.retrieve_mhs_attributes_value.return_value = test_utilities.awaitable(None)
         self.cache.add_cache_value.return_value = test_utilities.awaitable(None)
@@ -54,17 +52,14 @@ class TestMHSAttributeLookup(TestCase):
 
         self.assertEqual(expected_mhs_attributes, attributes)
 
-    @async_test
     async def test_no_client(self):
         with self.assertRaises(ValueError):
             mhs_attribute_lookup.MHSAttributeLookup(None, self.cache)
 
-    @async_test
     async def test_no_cache(self):
         with self.assertRaises(ValueError):
             mhs_attribute_lookup.MHSAttributeLookup(mocks.mocked_sds_client(), None)
 
-    @async_test
     async def test_value_added_to_cache(self):
         handler = mhs_attribute_lookup.MHSAttributeLookup(mocks.mocked_sds_client(), self.cache)
         self.cache.retrieve_mhs_attributes_value.return_value = test_utilities.awaitable(None)
@@ -74,7 +69,6 @@ class TestMHSAttributeLookup(TestCase):
 
         self.cache.add_cache_value.assert_called_with(ODS_CODE, INTERACTION_ID, result)
 
-    @async_test
     async def test_sds_not_called_when_value_in_cache(self):
         expected_value = {"some-key": "some-value"}
         self.cache.retrieve_mhs_attributes_value.return_value = test_utilities.awaitable(expected_value)
@@ -85,7 +79,6 @@ class TestMHSAttributeLookup(TestCase):
         self.assertEqual(result, expected_value)
         handler.sds_client.assert_not_called()
 
-    @async_test
     async def test_should_not_propagate_exception_when_retrieving_cache_entry(self):
         self.cache.retrieve_mhs_attributes_value.side_effect = Exception
         self.cache.add_cache_value.return_value = test_utilities.awaitable(None)
@@ -95,7 +88,6 @@ class TestMHSAttributeLookup(TestCase):
 
         self.assertEqual(expected_mhs_attributes, attributes)
 
-    @async_test
     async def test_should_not_propagate_exception_when_storing_cache_entry(self):
         self.cache.retrieve_mhs_attributes_value.side_effect = test_utilities.awaitable(None)
         self.cache.add_cache_value.side_effect = None

--- a/mhs/spineroutelookup/lookup/tests/test_routing_reliability.py
+++ b/mhs/spineroutelookup/lookup/tests/test_routing_reliability.py
@@ -2,7 +2,6 @@ import unittest
 from unittest import mock
 
 from utilities import test_utilities
-from utilities.test_utilities import async_test
 
 import lookup.mhs_attribute_lookup as mhs_attribute_lookup
 import lookup.routing_reliability as rar
@@ -31,9 +30,8 @@ EXPECTED_RELIABILITY = {
 }
 
 
-class TestRoutingAndReliability(unittest.TestCase):
+class TestRoutingAndReliability(unittest.IsolatedAsyncioTestCase):
 
-    @async_test
     async def test_get_routing(self):
         router = self._configure_routing_and_reliability()
 
@@ -41,21 +39,18 @@ class TestRoutingAndReliability(unittest.TestCase):
 
         self.assertEqual(mhs_route_details, EXPECTED_ROUTING)
 
-    @async_test
     async def test_get_routing_bad_ods_code(self):
         router = self._configure_routing_and_reliability()
 
         with self.assertRaises(sds_exception.SDSException):
             await router.get_end_point("bad code", INTERACTION_ID)
 
-    @async_test
     async def test_get_routing_bad_interaction_id(self):
         router = self._configure_routing_and_reliability()
 
         with self.assertRaises(sds_exception.SDSException):
             await router.get_end_point(ODS_CODE, "bad interaction")
 
-    @async_test
     async def test_get_reliability(self):
         router = self._configure_routing_and_reliability()
 
@@ -63,21 +58,18 @@ class TestRoutingAndReliability(unittest.TestCase):
 
         self.assertEqual(reliability_details, EXPECTED_RELIABILITY)
 
-    @async_test
     async def test_get_reliability_bad_ods_code(self):
         router = self._configure_routing_and_reliability()
 
         with self.assertRaises(sds_exception.SDSException):
             await router.get_reliability("bad code", INTERACTION_ID)
 
-    @async_test
     async def test_get_reliability_bad_interaction_id(self):
         router = self._configure_routing_and_reliability()
 
         with self.assertRaises(sds_exception.SDSException):
             await router.get_reliability(ODS_CODE, "whew")
 
-    @async_test
     async def test_empty_handler(self):
         with self.assertRaises(ValueError):
             rar.RoutingAndReliability(None)

--- a/mhs/spineroutelookup/lookup/tests/test_sds_client.py
+++ b/mhs/spineroutelookup/lookup/tests/test_sds_client.py
@@ -1,7 +1,5 @@
 from copy import copy
-from unittest import TestCase
-
-from utilities.test_utilities import async_test
+from unittest import IsolatedAsyncioTestCase
 
 import lookup.sds_client as sds_client
 import lookup.sds_exception as re
@@ -37,9 +35,8 @@ expected_mhs_attributes = {
 }
 
 
-class TestSDSClient(TestCase):
+class TestSDSClient(IsolatedAsyncioTestCase):
 
-    @async_test
     async def test_mhs_details_lookup(self):
         client = mocks.mocked_sds_client()
 
@@ -53,7 +50,6 @@ class TestSDSClient(TestCase):
         # Assert exact number of attributes
         self.assertEqual(len(attributes), len(expected_mhs_attributes))
 
-    @async_test
     async def test_accredited(self):
         client = mocks.mocked_sds_client()
 
@@ -64,7 +60,6 @@ class TestSDSClient(TestCase):
         self.assertEqual(result[0]['attributes']['uniqueIdentifier'][0], ASID)
         self.assertEqual(len(result[0]['attributes']), 2)
 
-    @async_test
     async def test_get_mhs_lookup(self):
         client = mocks.mocked_sds_client()
 
@@ -78,7 +73,6 @@ class TestSDSClient(TestCase):
         # Assert exact number of attributes, minus the unique values
         self.assertEqual(len(attributes), len(expected_mhs_attributes))
 
-    @async_test
     async def test_should_return_result_as_dictionary(self):
         client = mocks.mocked_sds_client()
 
@@ -86,18 +80,15 @@ class TestSDSClient(TestCase):
 
         self.assertIsInstance(attributes, dict)
 
-    @async_test
     async def test_no_results(self):
         client = mocks.mocked_sds_client()
         with self.assertRaises(re.SDSException):
             await client.get_mhs_details("fake code", "fake interaction")
 
-    @async_test
     async def test_should_raise_error_if_no_connection_set(self):
         with self.assertRaises(ValueError):
             sds_client.SDSClient(None, "ou=search,o=base")
 
-    @async_test
     async def test_should_raise_error_if_no_search_base_set(self):
         with self.assertRaises(ValueError):
             sds_client.SDSClient(mocks.fake_ldap_connection(), None)


### PR DESCRIPTION
## Why

IsolatedAsyncioTestCase was introduced within Python 3.8, which was after the original creation of these tests.

By replacing the custom `async_test` implementation with `IsolatedAsyncioTestCase` it will make our tests more idiomatic and therefore more maintainable.

Additionally, the implementation of `async_test` uses `asyncio.coroutine`, a method which was deprecated in Python 3.8 and will be removed in Python 3.11

## Type of change

Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users