### PR TITLE
Fix LegacyKeyValueFormat warning in Dockerfile for ENV declarations

### DIFF
--- a/docker/inbound/Dockerfile
+++ b/docker/inbound/Dockerfile
@@ -15,8 +15,8 @@ COPY mhs/common/ /usr/src/app/mhs/common/
 COPY mhs/inbound/ /usr/src/app/mhs/inbound
 
 WORKDIR /usr/src/app/mhs/inbound
-ENV PYTHONPATH "${PYTHONPATH}:/usr/src/app/mhs/common"
-ENV PYTHONPATH "${PYTHONPATH}:/usr/src/app/common"
+ENV PYTHONPATH="${PYTHONPATH}:/usr/src/app/mhs/common"
+ENV PYTHONPATH="${PYTHONPATH}:/usr/src/app/common"
 
 RUN pipenv --python 3.11
 RUN pipenv install --deploy --ignore-pipfile

--- a/docker/outbound/Dockerfile
+++ b/docker/outbound/Dockerfile
@@ -18,8 +18,8 @@ COPY mhs/common/ /usr/src/app/mhs/common/
 COPY mhs/outbound/ /usr/src/app/mhs/outbound
 
 WORKDIR /usr/src/app/mhs/outbound
-ENV PYTHONPATH "${PYTHONPATH}:/usr/src/app/mhs/common"
-ENV PYTHONPATH "${PYTHONPATH}:/usr/src/app/common"
+ENV PYTHONPATH="${PYTHONPATH}:/usr/src/app/mhs/common"
+ENV PYTHONPATH="${PYTHONPATH}:/usr/src/app/common"
 
 RUN pipenv --python 3.11
 RUN pipenv install --deploy --ignore-pipfile

--- a/docker/spineroutelookup/Dockerfile
+++ b/docker/spineroutelookup/Dockerfile
@@ -17,8 +17,8 @@ COPY common/ /usr/src/app/common/
 COPY mhs/common/ /usr/src/app/mhs/common/
 COPY mhs/spineroutelookup/ /usr/src/app/mhs/spineroutelookup
 
-ENV PYTHONPATH "${PYTHONPATH}:/usr/src/app/mhs/common"
-ENV PYTHONPATH "${PYTHONPATH}:/usr/src/app/common"
+ENV PYTHONPATH="${PYTHONPATH}:/usr/src/app/mhs/common"
+ENV PYTHONPATH="${PYTHONPATH}:/usr/src/app/common"
 
 WORKDIR /usr/src/app/mhs/spineroutelookup
 


### PR DESCRIPTION
> LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 21)
> LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 22)

## Type of change

Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
