### PR TITLE
Replace deprecated assertEquals with assertEqual

### DIFF
--- a/mhs/common/mhs_common/messages/tests/test_ebxml_request_envelope.py
+++ b/mhs/common/mhs_common/messages/tests/test_ebxml_request_envelope.py
@@ -410,7 +410,7 @@ class TestEbxmlRequestEnvelope(test_ebxml_envelope.BaseTestEbxmlEnvelope):
             # Regression test for NIAD-2822
             message, _ = message_utilities.load_test_data(self.message_dir, 'ebxml_request_multibyte_character')
             parsed_message = ebxml_request_envelope.EbxmlRequestEnvelope.from_string(MULTIPART_MIME_HEADERS, message)
-            self.assertEquals(parsed_message.message_dictionary['hl7_message'], "<xml>¬ ❤️ 🧸</xml>")
+            self.assertEqual(parsed_message.message_dictionary['hl7_message'], "<xml>¬ ❤️ 🧸</xml>")
 
         with self.subTest(
             "A valid request containing a fragment of a GZIP compressed text/plain file. "


### PR DESCRIPTION
## Why

`assertEquals` is removed in Python 3.12

## Type of change

Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
