### PR TITLE
Update libssl-dev package in Dockerfiles to reflect package updates.

### DIFF
--- a/build-and-run-tests.sh
+++ b/build-and-run-tests.sh
@@ -18,6 +18,7 @@ run_unit_test_module() {
 
   if (
     cd "$module_path" && \
+    rm -rf test-reports && \
     pipenv install --dev --deploy --ignore-pipfile && \
     pipenv run unittests-cov && \
     pipenv run coverage-report

--- a/component-test.Dockerfile
+++ b/component-test.Dockerfile
@@ -5,7 +5,7 @@ FROM python:3.11-slim-bookworm
 RUN apt-get update  \
     && apt-get install -y --no-install-recommends \
       build-essential=12.9 \
-      libssl-dev=3.0.18-1~deb12u1 \
+      libssl-dev=3.0.18-1~deb12u2 \
       swig=4.1.0-0.2 \
       pkg-config=1.8.1-1 \
       libxml2-dev=2.9.14+dfsg-1.3~deb12u5 \

--- a/docker/inbound/Dockerfile
+++ b/docker/inbound/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.11-slim-bookworm AS base
 RUN apt-get update  \
     && apt-get install -y --no-install-recommends \
        build-essential=12.9 \
-       libssl-dev=3.0.18-1~deb12u1 \
+       libssl-dev=3.0.18-1~deb12u2 \
        libffi-dev=3.4.4-1 \
        libxml2-dev=2.9.14+dfsg-1.3~deb12u5 \
        libxslt1-dev=1.1.35-1+deb12u3 \

--- a/docker/outbound/Dockerfile
+++ b/docker/outbound/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.11-slim-bookworm AS base
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        build-essential=12.9 \
-       libssl-dev=3.0.18-1~deb12u1 \
+       libssl-dev=3.0.18-1~deb12u2 \
        swig=4.1.0-0.2 \
        pkg-config=1.8.1-1 \
        libxml2-dev=2.9.14+dfsg-1.3~deb12u5 \

--- a/docker/spineroutelookup/Dockerfile
+++ b/docker/spineroutelookup/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.11-slim-bookworm AS base
 RUN apt-get update  \
     && apt-get install -y --no-install-recommends \
        build-essential=12.9 \
-       libssl-dev=3.0.18-1~deb12u1 \
+       libssl-dev=3.0.18-1~deb12u2 \
        libxml2-dev=2.9.14+dfsg-1.3~deb12u5 \
        libxslt1-dev=1.1.35-1+deb12u3 \
        libffi-dev=3.4.4-1 \


### PR DESCRIPTION
## What

* Update libssl-dev package in Dockerfiles to reflect package updates.
* Add line to remove previous test runner results when running new tests to build and run tests scripts.

## Why

Running the test scripts now reports an error:

`ibssl-dev : Depends: libssl3 (= 3.0.18-1~deb12u1) but 3.0.18-1~deb12u2 is to be installed`

This needs to be updated across the Dockerfiles to reflect this.

Also added a line which removes previous run test results when a test is run again, to ensure that a large amount of results files are not accidentally retained.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
