### PR TITLE
NIAD-3273 Fix DuplicatePrimaryKeyError on MHS Outbound retry by using upsert instead of insert

### DIFF
--- a/common/persistence/dynamo_persistence_adaptor.py
+++ b/common/persistence/dynamo_persistence_adaptor.py
@@ -52,12 +52,7 @@ class DynamoPersistenceAdaptor(persistence_adaptor.PersistenceAdaptor):
             async with self.__get_dynamo_resource() as dynamo:
                 table = await dynamo.Table(self.table_name)
                 await table.put_item(
-                    Item=self.add_primary_key_field(_KEY, key, data),
-                    ConditionExpression=Attr(_KEY).not_exists())
-        except ClientError as e:
-            if e.response['Error']['Code'] == 'ConditionalCheckFailedException':
-                raise DuplicatePrimaryKeyError
-            raise
+                    Item=self.add_primary_key_field(_KEY, key, data))
         except Exception as e:
             raise RecordCreationError from e
 

--- a/common/persistence/mongo_persistence_adaptor.py
+++ b/common/persistence/mongo_persistence_adaptor.py
@@ -65,13 +65,13 @@ class MongoPersistenceAdaptor(persistence_adaptor.PersistenceAdaptor):
         logger.info('Adding data for {key} in table {table}', fparams={'key': key, 'table': self.table_name})
 
         try:
-            result = await asyncio.to_thread(
-                lambda: self.collection.insert_one(self.add_primary_key_field(_KEY, key, data))
+            await asyncio.to_thread(
+                lambda: self.collection.find_one_and_replace(
+                    {_KEY: key},
+                    self.add_primary_key_field(_KEY, key, data),
+                    upsert=True
+                )
             )
-            if not result.acknowledged:
-                raise RecordCreationError
-        except DuplicateKeyError as e:
-            raise DuplicatePrimaryKeyError from e
         except Exception as e:
             raise RecordCreationError from e
 

--- a/component-test.Dockerfile
+++ b/component-test.Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update  \
       swig=4.1.0-0.2 \
       pkg-config=1.8.1-1 \
       libxml2-dev=2.9.14+dfsg-1.3~deb12u5 \
-      libxslt1-dev=1.1.35-1+deb12u3 \
+      libxslt1-dev=1.1.35-1+deb12u4 \
       python3-dev=3.11.2-1+b1 \
       libffi-dev=3.4.4-1 \
     && apt-get clean \

--- a/docker/inbound/Dockerfile
+++ b/docker/inbound/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update  \
        libssl-dev=3.0.19-1~deb12u2 \
        libffi-dev=3.4.4-1 \
        libxml2-dev=2.9.14+dfsg-1.3~deb12u5 \
-       libxslt1-dev=1.1.35-1+deb12u3 \
+       libxslt1-dev=1.1.35-1+deb12u4 \
        pkg-config=1.8.1-1 \
        python3-dev=3.11.2-1+b1 \
        swig=4.1.0-0.2 \

--- a/docker/outbound/Dockerfile
+++ b/docker/outbound/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
        swig=4.1.0-0.2 \
        pkg-config=1.8.1-1 \
        libxml2-dev=2.9.14+dfsg-1.3~deb12u5 \
-       libxslt1-dev=1.1.35-1+deb12u3 \
+       libxslt1-dev=1.1.35-1+deb12u4 \
        python3-dev=3.11.2-1+b1 \
        libffi-dev=3.4.4-1 \
     && apt-get clean \

--- a/docker/spineroutelookup/Dockerfile
+++ b/docker/spineroutelookup/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update  \
        build-essential=12.9 \
        libssl-dev=3.0.19-1~deb12u2 \
        libxml2-dev=2.9.14+dfsg-1.3~deb12u5 \
-       libxslt1-dev=1.1.35-1+deb12u3 \
+       libxslt1-dev=1.1.35-1+deb12u4 \
        libffi-dev=3.4.4-1 \
        pkg-config=1.8.1-1 \
        python3-dev=3.11.2-1+b1 \

--- a/integration-tests/integration_tests/integration_tests/component_tests/component_persistence_adaptor_tests.py
+++ b/integration-tests/integration_tests/integration_tests/component_tests/component_persistence_adaptor_tests.py
@@ -89,7 +89,7 @@ class DbAdaptorsTests(unittest.IsolatedAsyncioTestCase):
                 value = await adaptor.get(other_key)
                 self.assertIsNone(value)
 
-    async def test_error_if_same_key_inserted_twice(self):
+    async def test_can_reinsert_same_key(self):
         for adaptor_type in PERSISTENCE_ADAPTOR_TYPES:
             with self.subTest(f"{adaptor_type}"):
                 adaptor = self.get_adaptor(adaptor_type)
@@ -98,14 +98,10 @@ class DbAdaptorsTests(unittest.IsolatedAsyncioTestCase):
                 self.keys += [key]
 
                 await adaptor.add(key, OTHER_DATA)
+                await adaptor.add(key, SAMPLE_DATA)
 
-                try:
-                    await adaptor.add(key, OTHER_DATA)
-                except MaxRetriesExceeded as e:
-                    cause = e.__cause__
-                    self.assertIsInstance(cause, DuplicatePrimaryKeyError)
-                else:
-                    self.fail(f"Expected '{type(DuplicatePrimaryKeyError)}' exception not raised")
+                value = await adaptor.get(key)
+                self.assertEqual(value, SAMPLE_DATA)
 
     async def test_error_if_data_to_add_has_primary_key_in(self):
         await self._test_error_if_data_has_primary_key_in(PersistenceAdaptor.add.__name__)


### PR DESCRIPTION
## What

Replace insert_one with find_one_and_replace using upsert=True in MongoPersistenceAdaptor.add. Updated the corresponding test to reflect the new behaviour.

Relates ticket: https://nhse-dsic.atlassian.net/browse/NIAD-3273

## Why

When an MHS Outbound request failed with a 500, the record was already written to MongoDB. Retrying with the same Message ID would then fail with a DuplicatePrimaryKeyError because insert_one does not allow duplicate keys. Using upsert means the retry will overwrite the existing record instead of erroring, allowing the request to be resent successfully.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
